### PR TITLE
48 fixes to adjusted view following datacontainer change

### DIFF
--- a/dm_regional_app/templatetags/table_tags.py
+++ b/dm_regional_app/templatetags/table_tags.py
@@ -4,14 +4,24 @@ register = template.Library()
 
 
 def convert_data_frame_to_html_table_headers(df):
+    """
+    This takes a dataframe
+    As this is not used for showing base rates, checks if "base" is in value and removes it
+    """
     html = "<tr>"
     for value in df.columns:
-        html += f'<th><p style="font-size:14px;">{value}</p></th>'
+        modified_value = value
+        if "base" in value.lower():
+            modified_value = value.lower().replace("base", "").strip().capitalize()
+        html += f'<th><p style="font-size:14px;">{modified_value}</p></th>'
     html += "</tr>"
     return html
 
 
 def convert_data_frame_to_html_table_headers_form(df):
+    """
+    This takes only the dataframe but adds an additional column to allow for the form to be integrated
+    """
     html = "<tr>"
     for value in df.columns:
         html += f"<th><p>{value.capitalize()}</p></th>"
@@ -20,6 +30,11 @@ def convert_data_frame_to_html_table_headers_form(df):
 
 
 def convert_data_frame_to_html_table_rows_form(df, form):
+    """
+    This takes both dataframe and form
+    It will create a row for each item that shares an index
+    The form input field will be at the end of each row
+    """
     html = ""
     for index, row in df.iterrows():
         row_html = "<tr>"

--- a/dm_regional_app/views.py
+++ b/dm_regional_app/views.py
@@ -130,8 +130,7 @@ def entry_rates(request):
                     session_scenario.adjusted_numbers = data
                     session_scenario.save()
 
-                config = Config()
-                stats = PopulationStats(historic_data, config)
+                stats = PopulationStats(historic_data)
 
                 adjusted_prediction = predict(
                     data=historic_data,
@@ -224,8 +223,7 @@ def exit_rates(request):
                     session_scenario.adjusted_rates = data
                     session_scenario.save()
 
-                config = Config()
-                stats = PopulationStats(historic_data, config)
+                stats = PopulationStats(historic_data)
 
                 adjusted_prediction = predict(
                     data=historic_data,
@@ -318,8 +316,7 @@ def transition_rates(request):
                     session_scenario.adjusted_rates = data
                     session_scenario.save()
 
-                config = Config()
-                stats = PopulationStats(historic_data, config)
+                stats = PopulationStats(historic_data)
 
                 adjusted_prediction = predict(
                     data=historic_data,
@@ -454,8 +451,7 @@ def adjusted(request):
         else:
             empty_dataframe = False
 
-            config = Config()
-            stats = PopulationStats(historic_data, config)
+            stats = PopulationStats(historic_data)
 
             # Call predict function with default dates
             prediction = predict(

--- a/ssda903/multinomial.py
+++ b/ssda903/multinomial.py
@@ -4,7 +4,7 @@ from typing import Any, Iterable, Optional, Union
 
 import numpy as np
 import pandas as pd
-from demand_model.base import BaseModelPredictor, combine_rates
+from demand_model.base import BaseModelPredictor
 from demand_model.multinomial.utils import (
     build_transition_rates_matrix,
     fill_missing_states,
@@ -29,6 +29,23 @@ class Prediction:
 class NextPrediction:
     population: np.ndarray
     variance: np.ndarray
+
+
+def combine_rates(rate1: pd.Series, rate2: pd.Series) -> pd.Series:
+    """'
+    This has been updated to a multiplication method.
+    Fill value=1 allows any values missing from the adjustment series to remain unchanged in the transition rates
+    Any rates not present in rate1 will not be included in output
+    """
+    rate1, rate2 = rate1.align(rate2, fill_value=1)
+
+    # Create a mask to identify where rate1 is missing but rate2 is not
+    mask = (rate1 != 1) | (rate2 == 1)
+
+    # Apply the mask to exclude undesired cases
+    rates = (rate1 * rate2)[mask]
+    rates.index.names = ["from", "to"]
+    return rates
 
 
 class MultinomialPredictor(BaseModelPredictor):

--- a/ssda903/multinomial.py
+++ b/ssda903/multinomial.py
@@ -34,13 +34,13 @@ class NextPrediction:
 def combine_rates(rate1: pd.Series, rate2: pd.Series) -> pd.Series:
     """'
     This has been updated to a multiplication method.
-    Fill value=1 allows any values missing from the adjustment series to remain unchanged in the transition rates
-    Any rates not present in rate1 will not be included in output
+    Excludes cases where rate1 is missing.
     """
-    rate1, rate2 = rate1.align(rate2, fill_value=1)
+    # Align the series with a left join to retain all indices from rate1
+    rate1, rate2 = rate1.align(rate2, join="left", fill_value=1)
 
-    # Create a mask to identify where rate1 is missing but rate2 is not
-    mask = (rate1 != 1) | (rate2 == 1)
+    # Create a mask to identify where rate1 is not missing
+    mask = ~rate1.isna()
 
     # Apply the mask to exclude undesired cases
     rates = (rate1 * rate2)[mask]

--- a/ssda903/population_stats.py
+++ b/ssda903/population_stats.py
@@ -23,7 +23,10 @@ class PopulationStats:
         """
         df = self.df.copy()
 
-        df["bin"] = df.apply(lambda c: (c.age_bin, c.placement_type), axis=1)
+        df["bin"] = df.apply(
+            lambda c: f"{c.age_bin} - {c.placement_type.capitalize()}",
+            axis=1,
+        )
 
         endings = df.groupby(["DEC", "bin"]).size()
         endings.name = "nof_decs"
@@ -69,11 +72,12 @@ class PopulationStats:
     def transitions(self):
         transitions = self.df.copy()
         transitions["start_bin"] = transitions.apply(
-
-            lambda c: (c.age_bin, c.placement_type), axis=1
+            lambda c: f"{c.age_bin} - {c.placement_type.capitalize()}",
+            axis=1,
         )
         transitions["end_bin"] = transitions.apply(
-            lambda c: (c.age_bin, c.placement_type_after), axis=1
+            lambda c: f"{c.age_bin} - {c.placement_type_after.capitalize()}",
+            axis=1,
         )
         transitions = transitions.groupby(["start_bin", "end_bin", "DEC"]).size()
         transitions = (
@@ -139,7 +143,10 @@ class PopulationStats:
 
         # Only look at episodes starting in analysis period
         df = df[(df["DECOM"] >= start_date) & (df["DECOM"] <= end_date)].copy()
-        df["to"] = df.apply(lambda c: (c.age_bin, c.placement_type), axis=1)
+        df["to"] = df.apply(
+            lambda c: f"{c.age_bin} - {c.placement_type.capitalize()}",
+            axis=1,
+        )
 
         # Group by age bin and placement type
         df = (

--- a/ssda903/predictor.py
+++ b/ssda903/predictor.py
@@ -4,7 +4,7 @@ from typing import Iterable, Optional, Union
 import pandas as pd
 from dateutil.relativedelta import relativedelta
 
-from ssda903 import Config, PopulationStats
+from ssda903 import PopulationStats
 from ssda903.multinomial import MultinomialPredictor, Prediction
 
 


### PR DESCRIPTION
A couple of fixes:
Adjusted page wasn't running post merge, should now be working
Rate adjustments that don't match an initial rate in the prediction will be ignored
Tables on the main adjustment page no longer say 'base', tables on form input page do say base.