### PR TITLE
47 bring costs back into model code

### DIFF
--- a/dm_regional_app/charts.py
+++ b/dm_regional_app/charts.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-from demand_model.multinomial.predictor import Prediction
 
+from ssda903.multinomial import Prediction
 from ssda903.population_stats import PopulationStats
 
 

--- a/dm_regional_app/management/commands/sandbox.py
+++ b/dm_regional_app/management/commands/sandbox.py
@@ -40,13 +40,30 @@ class Command(BaseCommand):
             {
                 "Fostering (Friend/Relative)": 0.45,
                 "Fostering (In-house)": 0.35,
-                "Residential (In-house)": 1.2,
+                "Fostering (IFA)": 0.4,
+                "Residential (In-house)": 0.8,
+                "Residential (External)": 0.4,
             }
         )
 
-        costs = forecast_costs(prediction, proportion_adjustment=proportion_adjustment)
+        cost_adjustment = pd.Series(
+            {
+                "Fostering (Friend/Relative)": 120,
+                "Fostering (In-house)": 160,
+                "Residential (In-house)": 900,
+            }
+        )
 
-        print(costs)
+        proportion_adjustment = None
+
+        costs = forecast_costs(
+            prediction,
+            proportion_adjustment=proportion_adjustment,
+            cost_adjustment=cost_adjustment,
+        )
+
+        print(costs.proportions)
+        print(costs.costs)
 
         # print(pop.stock)
         # print(dc.enriched_view)

--- a/dm_regional_app/management/commands/sandbox.py
+++ b/dm_regional_app/management/commands/sandbox.py
@@ -3,8 +3,6 @@ from typing import Optional
 
 import pandas as pd
 from dateutil.relativedelta import relativedelta
-from demand_model import MultinomialPredictor
-from demand_model.multinomial.predictor import Prediction
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.storage import default_storage
@@ -12,12 +10,10 @@ from django.core.management.base import BaseCommand
 from django.shortcuts import get_object_or_404
 
 from dm_regional_app.models import SavedScenario, SessionScenario
-from ssda903 import (
-    Config,
-    DemandModellingDataContainer,
-    PopulationStats,
-    StorageDataStore,
-)
+from ssda903 import DemandModellingDataContainer, PopulationStats, StorageDataStore
+from ssda903.config import Costs
+from ssda903.costs import forecast_costs
+from ssda903.predictor import predict
 
 User = get_user_model()
 
@@ -28,18 +24,35 @@ class Command(BaseCommand):
         for t in thing:
             print(t.profile.la)"""
         datastore = StorageDataStore(default_storage, settings.DATA_SOURCE)
-        config = Config()
-        dc = DemandModellingDataContainer(datastore, config)
-        pop = PopulationStats(dc.enriched_view, config)
+        dc = DemandModellingDataContainer(datastore)
+        pop = PopulationStats(dc.enriched_view)
 
         data = dc.enriched_view
-        # print(data.loc[data.UASC == True])
+        # print(data.columns)
+
+        prediction = predict(
+            data=data,
+            reference_start_date=dc.start_date,
+            reference_end_date=dc.end_date,
+        )
+
+        proportion_adjustment = pd.Series(
+            {
+                "Fostering (Friend/Relative)": 0.45,
+                "Fostering (In-house)": 0.35,
+                "Residential (In-house)": 1.2,
+            }
+        )
+
+        costs = forecast_costs(prediction, proportion_adjustment=proportion_adjustment)
+
+        print(costs)
 
         # print(pop.stock)
         # print(dc.enriched_view)
-        session_scenario = get_object_or_404(SessionScenario, pk=1)
-        print(session_scenario.historic_filters)
-        print(type(session_scenario.historic_filters))
+        # session_scenario = get_object_or_404(SessionScenario, pk=1)
+        # print(session_scenario.historic_filters)
+        # print(type(session_scenario.historic_filters))
 
         """
         

--- a/ssda903/config/_costs.py
+++ b/ssda903/config/_costs.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Generator
 
+import pandas as pd
+
 from ssda903.config._placement_categories import PlacementCategories, PlacementCategory
 
 
@@ -34,27 +36,27 @@ class Costs(Enum):
     FOSTER_FRIEND_RELATION = CostItem(
         label="Fostering (Friend/Relative)",
         category=PlacementCategories.FOSTERING.value,
-        defaults=CostDefaults(cost_per_day=100, proportion=1),
+        defaults=CostDefaults(cost_per_day=100, proportion=0.3),
     )
     FOSTER_IN_HOUSE = CostItem(
         label="Fostering (In-house)",
         category=PlacementCategories.FOSTERING.value,
-        defaults=CostDefaults(cost_per_day=150, proportion=1),
+        defaults=CostDefaults(cost_per_day=150, proportion=0.3),
     )
     FOSTER_IFA = CostItem(
         label="Fostering (IFA)",
         category=PlacementCategories.FOSTERING.value,
-        defaults=CostDefaults(cost_per_day=250, proportion=1),
+        defaults=CostDefaults(cost_per_day=250, proportion=0.4),
     )
     RESIDENTIAL_IN_HOUSE = CostItem(
         label="Residential (In-house)",
         category=PlacementCategories.RESIDENTIAL.value,
-        defaults=CostDefaults(cost_per_day=1000, proportion=1),
+        defaults=CostDefaults(cost_per_day=1000, proportion=0.5),
     )
     RESIDENTIAL_EXTERNAL = CostItem(
         label="Residential (External)",
         category=PlacementCategories.RESIDENTIAL.value,
-        defaults=CostDefaults(cost_per_day=1000, proportion=1),
+        defaults=CostDefaults(cost_per_day=1000, proportion=0.5),
     )
     SUPPORTED = CostItem(
         label="Supported accomodation",
@@ -64,17 +66,17 @@ class Costs(Enum):
     SECURE_HOME = CostItem(
         label="Secure home",
         category=PlacementCategories.OTHER.value,
-        defaults=CostDefaults(cost_per_day=1000, proportion=1),
+        defaults=CostDefaults(cost_per_day=1000, proportion=0.3),
     )
     PLACED_WITH_FAMILY = CostItem(
         label="Placed with family",
         category=PlacementCategories.OTHER.value,
-        defaults=CostDefaults(cost_per_day=1000, proportion=1),
+        defaults=CostDefaults(cost_per_day=1000, proportion=0.3),
     )
     OTHER = CostItem(
         label="Other",
         category=PlacementCategories.OTHER.value,
-        defaults=CostDefaults(cost_per_day=1000, proportion=1),
+        defaults=CostDefaults(cost_per_day=1000, proportion=0.4),
     )
 
     @classmethod
@@ -84,3 +86,11 @@ class Costs(Enum):
         for cost in cls:
             if cost.value.category == category:
                 yield cost
+
+    @classmethod
+    def to_dataframe(cls):
+        data = {
+            "cost": {item.value.label: item.value.defaults.cost_per_day for item in cls}
+        }
+        df = pd.DataFrame(data)
+        return df

--- a/ssda903/costs.py
+++ b/ssda903/costs.py
@@ -1,0 +1,126 @@
+from dataclasses import dataclass
+from decimal import Decimal, getcontext
+from typing import Iterable, Optional, Union
+
+import pandas as pd
+
+from ssda903.config import Costs, PlacementCategories
+from ssda903.multinomial import Prediction
+
+# Set the precision for decimal operations
+getcontext().prec = 6
+
+
+@dataclass
+class CostForecast:
+    population: pd.DataFrame
+    cost_adjustment: pd.DataFrame
+
+
+def get_cost_items_for_category(category_label: str):
+    """
+    Takes a placement category label and returns related enum costs in a list
+    """
+    cost_items = []
+    for cost in Costs:
+        if cost.value.category.label == category_label:
+            cost_items.append(cost.value)
+    return cost_items
+
+
+def normalize_proportions(cost_items, proportion_adjustment):
+    """
+    This function makes sure the proportions for each category sum to 1
+
+    It will prioritise proportions in the proportion adjustment series, eg
+    If proportion adjustments sum to less than 1 but total proportions sum to
+    more than 1, this will be adjusted via changing proportions not in the
+    adjustment series.
+
+    If the adjustment total sums to more than 1, other proportions will
+    scale to 0 and the proportions in the adjustment series will be scaled
+    to sum to 1.
+    """
+    adjustment_total = 0
+    remaining_total = 0
+
+    # Calculate the total of adjustment proportions and remaining proportions
+    for item in cost_items:
+        if item.label in proportion_adjustment.index:
+            adjustment_total += proportion_adjustment[item.label]
+        else:
+            remaining_total += item.defaults.proportion
+
+    if adjustment_total >= 1:
+        # Set remaining proportions to 0 and scale down adjustment proportions
+        scale_factor = Decimal("1") / Decimal(adjustment_total)
+        for item in cost_items:
+            print(item, adjustment_total, scale_factor)
+            if item.label in proportion_adjustment.index:
+                item.defaults.proportion = float(
+                    Decimal(proportion_adjustment[item.label]) * scale_factor
+                )
+                print(item.defaults.proportion)
+            else:
+                item.defaults.proportion = 0
+    else:
+        # Adjust remaining proportions to make the total sum to 1
+        scale_factor = (
+            (Decimal("1") - Decimal(adjustment_total)) / Decimal(remaining_total)
+            if remaining_total > 0
+            else 0
+        )
+        for item in cost_items:
+            print(item, adjustment_total, remaining_total, scale_factor)
+            if item.label in proportion_adjustment.index:
+                item.defaults.proportion = proportion_adjustment[item.label]
+            else:
+                item.defaults.proportion *= float(scale_factor)
+
+
+def forecast_costs(
+    data: Prediction,
+    cost_adjustment: Union[pd.Series, Iterable[pd.Series]] = None,
+    proportion_adjustment: Union[pd.Series, Iterable[pd.Series]] = None,
+    # inflation? True/false
+) -> CostForecast:
+    """
+    This will take a population and translate it to a cost.
+    """
+
+    forecast_population = data.population
+    processed_categories = set()
+
+    # Filter out columns that contain the not in care population
+    columns_to_keep = [
+        col for col in forecast_population.columns if "Not in care" not in col
+    ]
+    # Return the dataframe with only the in care population
+    forecast_population = forecast_population[columns_to_keep]
+
+    cost_forecast = pd.DataFrame(index=forecast_population.index)
+    for column in forecast_population.columns:
+        # for each column, create a new series where we will sum the total cost output
+        total_cost_series = pd.Series(0, index=forecast_population.index)
+
+        for category in PlacementCategories:
+            # for each category, check if the category label is in the column header
+            if (
+                category.value.label in column
+                and category.value.label not in processed_categories
+            ):
+                processed_categories.add(category.value.label)
+                cost_items = get_cost_items_for_category(category.value.label)
+
+                # Apply proportion adjustments
+                normalize_proportions(cost_items, proportion_adjustment)
+
+                for cost_item in cost_items:
+                    # for each cost item, multiply by cost per day and proportion, then sum together
+                    cost_per_day = cost_item.defaults.cost_per_day
+                    proportion = cost_item.defaults.proportion
+                    total_cost_series += (
+                        forecast_population[column] * cost_per_day * proportion
+                    )
+        cost_forecast[column] = total_cost_series
+    return cost_forecast

--- a/ssda903/tests/test_costs.py
+++ b/ssda903/tests/test_costs.py
@@ -14,7 +14,7 @@ class TestCosts(unittest.TestCase):
             },
             "defaults": {
                 "cost_per_day": 100,
-                "proportion": 1,
+                "proportion": 0.3,
             },
         }
         self.assertEqual(cost_item.toJSON(), expected_json)


### PR DESCRIPTION
Added costs.py and code to take the prediction population and create an output of costs.

Base proportions and costs are stored in an enum connected to placementcategories so function retrieves these.

Proportion adjustment logic:

- If a proportion is inputted by the proportion adjustment series, it should remain the same unless related items in the proportion_adjustment series sum to more than 1 (e.g. all fostering must sum to 1)
- Other proportions not in the adjustment series will therefore be scaled down to sum the total to 1
- If proportions in the adjustment series do sum to more than 1 then these will be scaled down to 1 and other related items reduced to 0

Cost adjustment logic:

- Cost adjustments replace enum costs - easy!

There is nothing functional in the django app using this code yet - I suggest using sandbox.py to test out the code. `python manage.py sandbox`