### PR TITLE
Datacontainer additional

### DIFF
--- a/dm_regional_app/views.py
+++ b/dm_regional_app/views.py
@@ -642,17 +642,6 @@ def historic_data(request):
         ]["CHILD"].nunique()
 
         stats = PopulationStats(data)
-        print(
-            datacontainer.enriched_view[
-                [
-                    "CHILD",
-                    "PLACE",
-                    "PLACE_PROVIDER",
-                    "placement_type",
-                    "placement_type_detail",
-                ]
-            ].head(50)
-        )
 
         chart = historic_chart(stats)
 

--- a/dm_regional_app/views.py
+++ b/dm_regional_app/views.py
@@ -642,6 +642,17 @@ def historic_data(request):
         ]["CHILD"].nunique()
 
         stats = PopulationStats(data)
+        print(
+            datacontainer.enriched_view[
+                [
+                    "CHILD",
+                    "PLACE",
+                    "PLACE_PROVIDER",
+                    "placement_type",
+                    "placement_type_detail",
+                ]
+            ].head(50)
+        )
 
         chart = historic_chart(stats)
 

--- a/ssda903/config/_costs.py
+++ b/ssda903/config/_costs.py
@@ -15,6 +15,8 @@ class CostDefaults:
 class CostItem:
     label: str
     category: PlacementCategory
+    placement_types: tuple
+    place_provider: tuple
     defaults: CostDefaults
 
     def toJSON(self) -> dict:
@@ -34,46 +36,87 @@ class Costs(Enum):
     FOSTER_FRIEND_RELATION = CostItem(
         label="Fostering (Friend/Relative)",
         category=PlacementCategories.FOSTERING.value,
+        placement_types=(
+            "U1",
+            "U2",
+            "U3",
+        ),
+        place_provider=(),
         defaults=CostDefaults(cost_per_day=100, proportion=1),
     )
     FOSTER_IN_HOUSE = CostItem(
         label="Fostering (In-house)",
         category=PlacementCategories.FOSTERING.value,
+        placement_types=(
+            "U4",
+            "U5",
+            "U6",
+        ),
+        place_provider=(
+            "PR1",
+            "PR2",
+            "PR3",
+        ),
         defaults=CostDefaults(cost_per_day=150, proportion=1),
     )
     FOSTER_IFA = CostItem(
         label="Fostering (IFA)",
         category=PlacementCategories.FOSTERING.value,
+        placement_types=(
+            "U4",
+            "U5",
+            "U6",
+        ),
+        place_provider=("PR4", "PR5"),
         defaults=CostDefaults(cost_per_day=250, proportion=1),
     )
     RESIDENTIAL_IN_HOUSE = CostItem(
         label="Residential (In-house)",
         category=PlacementCategories.RESIDENTIAL.value,
+        placement_types=("K2",),
+        place_provider=(
+            "PR1",
+            "PR2",
+            "PR3",
+        ),
         defaults=CostDefaults(cost_per_day=1000, proportion=1),
     )
     RESIDENTIAL_EXTERNAL = CostItem(
         label="Residential (External)",
         category=PlacementCategories.RESIDENTIAL.value,
+        placement_types=("K2",),
+        place_provider=("PR4", "PR5"),
         defaults=CostDefaults(cost_per_day=1000, proportion=1),
     )
     SUPPORTED = CostItem(
         label="Supported accomodation",
         category=PlacementCategories.SUPPORTED.value,
+        placement_types=(
+            "H5",
+            "P2",
+        ),
+        place_provider=(),
         defaults=CostDefaults(cost_per_day=1000, proportion=1),
     )
     SECURE_HOME = CostItem(
         label="Secure home",
-        category=PlacementCategories.OTHER.value,
+        category=PlacementCategories.OTHER.value,  # @Michael note - on 903 guidance this is under residential?
+        placement_types=("K1"),
+        place_provider=(),
         defaults=CostDefaults(cost_per_day=1000, proportion=1),
     )
     PLACED_WITH_FAMILY = CostItem(
-        label="Placed with family",
+        label="Placed with family",  # M note - used placed with parents code
         category=PlacementCategories.OTHER.value,
+        placement_types=("P1",),
+        place_provider=(),
         defaults=CostDefaults(cost_per_day=1000, proportion=1),
     )
     OTHER = CostItem(
         label="Other",
         category=PlacementCategories.OTHER.value,
+        placement_types=(),
+        place_provider=(),
         defaults=CostDefaults(cost_per_day=1000, proportion=1),
     )
 
@@ -84,3 +127,42 @@ class Costs(Enum):
         for cost in cls:
             if cost.value.category == category:
                 yield cost
+
+    @classmethod
+    def values(cls) -> list[CostItem]:
+        return [a.value for a in cls._members_by_category()]
+
+    @classmethod
+    def _members_by_category(cls) -> list["Costs"]:
+        """
+        Returns a list of all members of the enum ordered by category.
+        """
+        return sorted(list(cls.__members__.values()), key=lambda x: x.value.category)
+
+    @classmethod
+    def get_placement_type_map(cls) -> dict[str, CostItem]:
+        """
+        Returns a dictionary mapping (placement_type, provider) to PlacementCategory.
+        For example:
+        {
+            ("K2", "PR1"): <PlacementCategory: Residential>,
+            ("K2", "PR2"): <PlacementCategory: Residential>,
+            ("U1", "PR3"): <PlacementCategory: Fostering>,
+            ...
+        }
+        """
+        placement_type_map = {}
+
+        for c in cls.values():
+            for placement_type in c.placement_types:
+                if c.place_provider:
+                    # Create entries for each specific provider
+                    for provider in c.place_provider:
+                        placement_type_map[(placement_type, provider)] = c
+                else:
+                    # Create a generic entry that matches any provider
+                    placement_type_map[
+                        (placement_type, "")
+                    ] = c  # Empty string indicates match any provider
+
+        return placement_type_map

--- a/ssda903/config/_costs.py
+++ b/ssda903/config/_costs.py
@@ -73,7 +73,12 @@ class Costs(Enum):
     RESIDENTIAL_IN_HOUSE = CostItem(
         label="Residential (In-house)",
         category=PlacementCategories.RESIDENTIAL.value,
-        placement_types=("K2",),
+        placement_types=(
+            "K2",
+            "R1",
+            "P3",
+            "S1",
+        ),
         place_provider=(
             "PR1",
             "PR2",
@@ -84,7 +89,12 @@ class Costs(Enum):
     RESIDENTIAL_EXTERNAL = CostItem(
         label="Residential (External)",
         category=PlacementCategories.RESIDENTIAL.value,
-        placement_types=("K2",),
+        placement_types=(
+            "K2",
+            "R1",
+            "P3",
+            "S1",
+        ),
         place_provider=("PR4", "PR5"),
         defaults=CostDefaults(cost_per_day=1000, proportion=1),
     )
@@ -101,7 +111,7 @@ class Costs(Enum):
     SECURE_HOME = CostItem(
         label="Secure home",
         category=PlacementCategories.OTHER.value,  # @Michael note - on 903 guidance this is under residential?
-        placement_types=("K1"),
+        placement_types=("K1",),
         place_provider=(),
         defaults=CostDefaults(cost_per_day=1000, proportion=1),
     )

--- a/ssda903/config/_placement_categories.py
+++ b/ssda903/config/_placement_categories.py
@@ -69,6 +69,8 @@ class PlacementCategories(Enum):
         placement_types=(
             "K2",
             "R1",
+            "P3",
+            "S1",
         ),
         index=1,
     )

--- a/ssda903/datacontainer.py
+++ b/ssda903/datacontainer.py
@@ -229,11 +229,36 @@ class DemandModellingDataContainer:
 
     @cached_property
     def start_date(self) -> date:
-        return self.combined_data[["DECOM", "DEC"]].min().min().date()
+        # Find the minimum value in the 'DEC' column
+        min_dec = self.combined_data["DEC"].min()
+
+        # Extract the month and year from the min_dec date
+        min_dec_month = min_dec.month
+        min_dec_year = min_dec.year
+
+        # Determine the start_date based on the month of min_dec
+        if 4 <= min_dec_month <= 12:  # April to December
+            start_date = date(min_dec_year, 4, 1)
+        else:  # January to March
+            start_date = date(min_dec_year - 1, 4, 1)
+
+        return start_date
 
     @cached_property
     def end_date(self) -> date:
-        return self.combined_data[["DECOM", "DEC"]].max().max().date()
+        max_dec_decom = self.combined_data[["DECOM", "DEC"]].max().max().date()
+
+        # Extract the month and year from the max_dec_decom date
+        max_dec_decom_month = max_dec_decom.month
+        max_dec_decom_year = max_dec_decom.year
+
+        # Determine the start_date based on the month of max_dec_decom
+        if 4 <= max_dec_decom_month <= 12:  # April to December
+            end_date = date(max_dec_decom_year - 1, 3, 31)
+        else:  # January to March
+            end_date = date(max_dec_decom_year, 3, 31)
+
+        return end_date
 
     @cached_property
     def unique_las(self) -> pd.Series:


### PR DESCRIPTION
- fix start_date definition (lines 231-232) to:
find min(DEC)
if min(DEC) in Apr-Dec (it usually will be); assign start_date as 01/04/{year of DEC}
if min(DEC) in Jan-Mar; assign start_date as 01/04/{year of DEC - 1}

- fix end_date definition (lines 235-236) to:
find max(DEC/DECOM)
if max(DEC/DECOM) in Jan-Mar; assign end_date as 31/03/{year of max DEC/DECOM}
if max(DEC/DECOM) in Apr-Dec; assign end_date as 31/03/{year of max DEC/DECOM +1}

- check add_related_placement_type() (lines 313-338); currently this assigns NOT_IN_CARE where there's a null for the previous or subsequent placement type. 

I probably spent way too long on this! My initial thought was that this doesn't actually matter as we don't allow users to select dates prior to start date or post end date in the app - the only time a not in care marker would be incorrect in this instance is missing data as we don't hold the previous episode. There is no other way of working out an entry/exit from care as far as I can tell. Still went through the motions to prove this theory. The code follows the following logic:
If DECOM before or equal to datacontainer.start_date AND new column currently NAN (this is due to age transitions - there may be 'full placements' prior to start date where they are continuous due to new age placements. This could be adjusted if moving this transformation prior to adding aging placements) - add None for previous placement (Michael you can confirm whether equal to is required in this instance)
If DEC is blank (e.g. placement has no end date) add None for next placement.
Where placements are not continuous, add Not in care for interim placement
For all other Nans, add Not in care.

This did end up leading to a very small change in Entry rates which I've been unable to account for - 
(Original) 10 to 16 Fostering 0.1114 
(New) 10 to 16 Fostering 0.1105 
This is not because of a placement beginning on the start date as the earliest start date is sometime in August. I was running this on the default values if you want to check - so datacontainer start date and end date (the version in this branch) if you want to recreate.

The 'None' values will be automatically ignored as the placement bins are created via the Enum categories rather than the column values.

- add the more granular placement category as a new field for the placements.
