### PR TITLE
59 add graph lines showing model states

### DIFF
--- a/dm_regional_app/charts.py
+++ b/dm_regional_app/charts.py
@@ -177,19 +177,19 @@ def prediction_chart(historic_data: PopulationStats, prediction: Prediction, **k
 
     df.columns = ["from", "date", "forecast"]
     # Organises forecast data into dict of dfs by care type bucket
-    forecast_care_by_type_dfs = care_type_organiser(df)
+    forecast_care_by_type_dfs = care_type_organiser(df, "forecast", "from")
 
     # Dataframe containing total children in historic data
     df_hd = historic_data.stock.unstack().reset_index()
     df_hd.columns = ["from", "date", "historic"]
     # Organises historic data into dict of dfs by care type bucket
-    historic_care_by_type_dfs = care_type_organiser(df_hd)
+    historic_care_by_type_dfs = care_type_organiser(df_hd, "historic", "from")
 
     # Dataframe containing upper and lower confidence intervals
     df_ci = prediction.variance.unstack().reset_index()
-    df_ci.columns = ["from", "date", "variance"]
+    df_ci.columns = ["bin", "date", "variance"]
     # Organises confidence interval data into dict of dfs by care type bucket
-    df_ci = care_type_organiser(df_ci)
+    df_ci = care_type_organiser(df_ci, "variance", "bin")
 
     df_ci = apply_variances(forecast_care_by_type_dfs, df_ci)
 

--- a/dm_regional_app/charts.py
+++ b/dm_regional_app/charts.py
@@ -228,19 +228,14 @@ def prediction_chart(historic_data: PopulationStats, prediction: Prediction, **k
 
 def historic_chart(data: PopulationStats):
     df_hd = data.stock.unstack().reset_index()
-    df_hd.columns = ["from", "date", "value"]
-    df_hd = df_hd[["date", "value"]].groupby(by="date").sum().reset_index()
+    df_hd.columns = ["from", "date", "historic"]
+    historic_care_by_type_dfs = care_type_organiser(df_hd)
 
-    # visualise prediction using unstacked dataframe
-    fig = px.line(
-        df_hd,
-        y="value",
-        x="date",
-        labels={
-            "value": "Number of children",
-            "date": "Date",
-        },
-    )
+    fig = go.Figure()
+
+    # Add historical traces
+    fig = add_traces(None, historic_care_by_type_dfs, fig)
+
     fig.update_layout(title="Historic data")
     fig.update_yaxes(rangemode="tozero")
     fig_html = fig.to_html(full_html=False)

--- a/dm_regional_app/charts.py
+++ b/dm_regional_app/charts.py
@@ -232,7 +232,7 @@ def prediction_chart(historic_data: PopulationStats, prediction: Prediction, **k
 def historic_chart(data: PopulationStats):
     df_hd = data.stock.unstack().reset_index()
     df_hd.columns = ["from", "date", "historic"]
-    historic_care_by_type_dfs = care_type_organiser(df_hd)
+    historic_care_by_type_dfs = care_type_organiser(df_hd, "historic", "from")
 
     fig = go.Figure()
 

--- a/dm_regional_app/charts.py
+++ b/dm_regional_app/charts.py
@@ -168,29 +168,32 @@ def summary_tables(df):
 
 
 def prediction_chart(historic_data: PopulationStats, prediction: Prediction, **kwargs):
-    # pop start and end dates to visualise reference period
+    # Pop start and end dates to visualise reference period
     reference_start_date = kwargs.pop("reference_start_date")
     reference_end_date = kwargs.pop("reference_end_date")
 
-    # dataframe containing total children in prediction
+    # Dataframe containing total children in prediction
     df = prediction.population.unstack().reset_index()
 
     df.columns = ["from", "date", "forecast"]
+    # Organises forecast data into dict of dfs by care type bucket
     forecast_care_by_type_dfs = care_type_organiser(df)
 
-    # dataframe containing total children in historic data
+    # Dataframe containing total children in historic data
     df_hd = historic_data.stock.unstack().reset_index()
     df_hd.columns = ["from", "date", "historic"]
+    # Organises historic data into dict of dfs by care type bucket
     historic_care_by_type_dfs = care_type_organiser(df_hd)
 
-    # dataframe containing upper and lower confidence intervals
+    # Dataframe containing upper and lower confidence intervals
     df_ci = prediction.variance.unstack().reset_index()
     df_ci.columns = ["from", "date", "variance"]
+    # Organises confidence interval data into dict of dfs by care type bucket
     df_ci = care_type_organiser(df_ci)
 
     df_ci = apply_variances(forecast_care_by_type_dfs, df_ci)
 
-    # visualise prediction using unstacked dataframe
+    # Visualise prediction using unstacked dataframe
     fig = go.Figure()
 
     # Add forecast and historical traces

--- a/dm_regional_app/utils.py
+++ b/dm_regional_app/utils.py
@@ -100,6 +100,8 @@ def number_format(value):
 
 
 def care_type_organiser(df):
+    # Used on forecast, historic, and variance data to organise by care types,
+    # outpouts to a dictionary of dfs.
     care_type_dict = {}
 
     if "forecast" in df.columns:
@@ -126,6 +128,8 @@ def care_type_organiser(df):
 
 
 def apply_variances(care_by_type, ci_by_type):
+    # Applies pre-calculated variance make the df needed for plotting
+    # confidence intervals.
     for care_type in care_types:
         ci_by_type[care_type]["upper"] = (
             care_by_type[care_type]["forecast"] + ci_by_type[care_type]["variance"]
@@ -140,7 +144,6 @@ def apply_variances(care_by_type, ci_by_type):
 def add_traces(dfs_forecast, dfs_historic, fig):
     # Uses an accessible colour scheme from: https://personal.sron.nl/~pault/
     # Exact RGB codes cause some weirdness with plotly so text colours were used instead.
-
     colours = [
         "blue",
         "green",
@@ -151,7 +154,7 @@ def add_traces(dfs_forecast, dfs_historic, fig):
 
     for care_type, colour in zip(care_types, colours):
         if dfs_forecast:
-            # add forecast data
+            # Add forecast data.
             fig.add_trace(
                 go.Scatter(
                     x=dfs_forecast[care_type]["date"],
@@ -161,7 +164,7 @@ def add_traces(dfs_forecast, dfs_historic, fig):
                 )
             )
 
-        # add historic data
+        # Add historic data.
         fig.add_trace(
             go.Scatter(
                 x=dfs_historic[care_type]["date"],
@@ -176,6 +179,7 @@ def add_traces(dfs_forecast, dfs_historic, fig):
 
 def add_ci_traces(df, fig):
     for care_type in care_types:
+        # Add lower bounds for confidence intervals.
         fig.add_trace(
             go.Scatter(
                 x=df[care_type]["date"],
@@ -186,6 +190,7 @@ def add_ci_traces(df, fig):
             )
         )
 
+        # Add upper bounds for confidence intervals.
         fig.add_trace(
             go.Scatter(
                 x=df[care_type]["date"],

--- a/dm_regional_app/utils.py
+++ b/dm_regional_app/utils.py
@@ -86,3 +86,16 @@ def number_format(value):
         return f"-£{abs(value):,.2f}"
     else:
         return f"£{value:,.2f}"
+
+
+def care_type(row):
+    if "Fostering" in row:
+        return "Fostering"
+    if "Not in care" in row:
+        return "Not in care"
+    if "Residential" in row:
+        return "Residential"
+    if "Other" in row:
+        return "Other"
+    if "Supported" in row:
+        return "Supported"

--- a/dm_regional_app/utils.py
+++ b/dm_regional_app/utils.py
@@ -88,14 +88,33 @@ def number_format(value):
         return f"£{value:,.2f}"
 
 
-def care_type(row):
-    if "Fostering" in row:
-        return "Fostering"
-    if "Not in care" in row:
-        return "Not in care"
-    if "Residential" in row:
-        return "Residential"
-    if "Other" in row:
-        return "Other"
-    if "Supported" in row:
-        return "Supported"
+def care_type_organiser(df):
+    care_types = [
+        "Total",
+        "Fostering",
+        "Not in care",
+        "Residential",
+        "Other",
+        "Supported",
+    ]
+    care_type_dict = {}
+
+    if "forecast" in df.columns:
+        data_type = "forecast"
+    elif "historic" in df.columns:
+        data_type = "historic"
+
+    for care_type in care_types:
+        if care_type == "Total":
+            care_type_df = df[df["from"].apply(lambda x: "Not in care" in x) == False]
+        else:
+            care_type_df = df[df["from"].str.contains(care_type)]
+
+        care_type_df = (
+            care_type_df[["date", data_type]].groupby("date").sum().reset_index()
+        )
+        care_type_df["date"] = pd.to_datetime(care_type_df["date"]).dt.date
+
+        care_type_dict[care_type] = care_type_df
+
+    return care_type_dict

--- a/dm_regional_app/utils.py
+++ b/dm_regional_app/utils.py
@@ -11,7 +11,6 @@ import plotly.graph_objects as go
 care_types = [
     "Total",
     "Fostering",
-    "Not in care",
     "Residential",
     "Other",
     "Supported",
@@ -150,17 +149,17 @@ def add_traces(dfs_forecast, dfs_historic, fig):
         "purple",
     ]
 
-    care_types.remove("Not in care")
     for care_type, colour in zip(care_types, colours):
-        # add forecast data
-        fig.add_trace(
-            go.Scatter(
-                x=dfs_forecast[care_type]["date"],
-                y=dfs_forecast[care_type]["forecast"],
-                name=f"Forecast ({care_type})",
-                line=dict(color=colour, width=1.5),
+        if dfs_forecast:
+            # add forecast data
+            fig.add_trace(
+                go.Scatter(
+                    x=dfs_forecast[care_type]["date"],
+                    y=dfs_forecast[care_type]["forecast"],
+                    name=f"Forecast ({care_type})",
+                    line=dict(color=colour, width=1.5),
+                )
             )
-        )
 
         # add historic data
         fig.add_trace(
@@ -176,7 +175,6 @@ def add_traces(dfs_forecast, dfs_historic, fig):
 
 
 def add_ci_traces(df, fig):
-    # care_types.remove('Not in care')
     for care_type in care_types:
         fig.add_trace(
             go.Scatter(


### PR DESCRIPTION
#closes 59

- Adds traces to historical and forecast charts breaking down forecast and historical data (where appropriate) into care type bucket.
- Uses a colour blind accessible colour palette (may not translate to grayscale but at that point we ought to add more than colour to differentiate between traces like triangles, crosses, squares etc).
- Allows highlighting/filtering traces using plotly's built in functionality.
- Splits most of the work into functions in the utils.py as they're used across both plotting functions.
- A bunch of these sub-functions use loops per care type, if there's a more efficient way I'm happy to change how its done.
- If anything isn't done in a preferred way/style etc. let me know!