### PR TITLE
feat: restrict admin view for staff users

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -40,3 +40,8 @@ class UserAdmin(DjangoUserAdmin):
     list_display = ("email", "first_name", "last_name", "is_staff")
     search_fields = ("email", "first_name", "last_name")
     ordering = ("email",)
+
+    def get_readonly_fields(self, request, obj=None):
+        if not request.user.is_superuser:
+            return ["is_superuser", "is_staff"]
+        return []


### PR DESCRIPTION
Only superusers can update the flags indicating if users are staff or superusers - this is to prevent staff users from mistakenly giving regular users the power to upload data
 
![image](https://github.com/user-attachments/assets/fc0ae010-e746-48df-bb4c-b21fb2218c58)
