### PR TITLE
issue with adjusted rates breaking projected costs page identified

### DIFF
--- a/dm_regional_app/charts.py
+++ b/dm_regional_app/charts.py
@@ -566,10 +566,11 @@ def transition_rate_changes(base, adjusted):
 
     df = df[df["base"] != df["adjusted"]]
 
+    df = transition_rate_table(df)
+
     if df.empty:
         return None
     else:
-        df = transition_rate_table(df)
         df = df[["From", "To", "base", "adjusted"]]
         df.columns = ["From", "To", "Base transition rate", "Adjusted transition rate"]
         df = df.round(4)
@@ -588,10 +589,11 @@ def exit_rate_changes(base, adjusted):
 
     df = df[df["base"] != df["adjusted"]]
 
+    df = exit_rate_table(df)
+
     if df.empty:
         return None
     else:
-        df = exit_rate_table(df)
         df = df[["Age Group", "Placement", "base", "adjusted"]]
         df.columns = ["Age Group", "Placement", "Base exit rate", "Adjusted exit rate"]
         df = df.round(4)
@@ -610,10 +612,11 @@ def entry_rate_changes(base, adjusted):
 
     df = df[df["base"] != df["adjusted"]]
 
+    df = entry_rate_table(df)
+
     if df.empty:
         return None
     else:
-        df = entry_rate_table(df)
         df = df[["Age Group", "Placement", "base", "adjusted"]]
         df.columns = [
             "Age Group",

--- a/dm_regional_app/charts.py
+++ b/dm_regional_app/charts.py
@@ -342,7 +342,12 @@ def exit_rate_table(data):
     df = df[df["to"].apply(lambda x: "Not in care" in x)]
 
     # creates new columns for age and placement from buckets
-    df[["Age Group", "Placement"]] = df["from"].str.split(" - ", expand=True)
+    try:
+        df[["Age Group", "Placement"]] = df["from"].str.split(" - ", expand=True)
+    # The above breaks if the data has no children leaving care, so instead we can return
+    # an empty dataframe in this instance.
+    except:
+        df[["Age Group", "Placement"]] = pd.NA
 
     # sets multiindex
     df.set_index(["from", "to"], inplace=True)


### PR DESCRIPTION
closes #91 

If changes are made to transition rates, when the exit rate table is calculated for the projected costs page, this gives an error where two columns are meant to be made from a .str.split() and no split can occur. This error occurs when there are no rows of data to split (after removing all data except rows where children are leaving care).

I've temporarily popped a try/except block in there as this works as a fix, but I'm not sure if this is an actual long term solution. Also, I wonder if we might need to account for this in other instances if there's a chance we might be trying to split where there is no data to split. If we find a long term solution, it might make sense to handle this in another function and use it each time we do thsi split?