### PR TITLE
Fix error - empty form causing empty dataframe JSON issue

### DIFF
--- a/dm_regional_app/utils.py
+++ b/dm_regional_app/utils.py
@@ -1,10 +1,8 @@
 import ast
 import json
-import re
 from datetime import date, datetime
 
 import pandas as pd
-import plotly.express as px
 import plotly.graph_objects as go
 
 from ssda903.config import PlacementCategories
@@ -214,3 +212,12 @@ def add_ci_traces(df, fig):
         )
 
     return fig
+
+
+def save_data_if_not_empty(session_scenario, data, attribute_name):
+    """
+    Checks if series or dataframe is not empty, and saves to attribute of model if not
+    """
+    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
+        setattr(session_scenario, attribute_name, data)
+        session_scenario.save()

--- a/dm_regional_app/views.py
+++ b/dm_regional_app/views.py
@@ -38,7 +38,7 @@ from dm_regional_app.forms import (
 )
 from dm_regional_app.models import DataSource, SavedScenario, SessionScenario
 from dm_regional_app.tables import SavedScenarioTable
-from dm_regional_app.utils import apply_filters, number_format
+from dm_regional_app.utils import apply_filters, number_format, save_data_if_not_empty
 from ssda903.config import PlacementCategories
 from ssda903.costs import (
     convert_historic_population_to_cost,
@@ -495,9 +495,7 @@ def weekly_costs(request):
 
                 else:
                     # Check that the dataframe or series saved in the form is not empty, then save
-                    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
-                        session_scenario.adjusted_costs = data
-                        session_scenario.save()
+                    save_data_if_not_empty(session_scenario, data, "adjusted_costs")
 
                 return redirect("costs")
 
@@ -622,9 +620,7 @@ def entry_rates(request):
 
                 else:
                     # Check that the dataframe or series saved in the form is not empty, then save
-                    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
-                        session_scenario.adjusted_numbers = data
-                        session_scenario.save()
+                    save_data_if_not_empty(session_scenario, data, "adjusted_numbers")
 
                 stats = PopulationStats(historic_data)
 
@@ -737,9 +733,7 @@ def exit_rates(request):
 
                 else:
                     # Check that the dataframe or series saved in the form is not empty, then save
-                    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
-                        session_scenario.adjusted_rates = data
-                        session_scenario.save()
+                    save_data_if_not_empty(session_scenario, data, "adjusted_rates")
 
                 stats = PopulationStats(historic_data)
 
@@ -853,9 +847,7 @@ def transition_rates(request):
 
                 else:
                     # Check that the dataframe or series saved in the form is not empty, then save
-                    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
-                        session_scenario.adjusted_rates = data
-                        session_scenario.save()
+                    save_data_if_not_empty(session_scenario, data, "adjusted_rates")
 
                 stats = PopulationStats(historic_data)
 

--- a/dm_regional_app/views.py
+++ b/dm_regional_app/views.py
@@ -395,8 +395,10 @@ def placement_proportions(request):
                     session_scenario.save()
 
                 else:
-                    session_scenario.adjusted_proportions = data
-                    session_scenario.save()
+                    # Check that the dataframe or series saved in the form is not empty, then save
+                    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
+                        session_scenario.adjusted_proportions = data
+                        session_scenario.save()
 
                 return redirect("costs")
 
@@ -492,8 +494,10 @@ def weekly_costs(request):
                     session_scenario.save()
 
                 else:
-                    session_scenario.adjusted_costs = data
-                    session_scenario.save()
+                    # Check that the dataframe or series saved in the form is not empty, then save
+                    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
+                        session_scenario.adjusted_costs = data
+                        session_scenario.save()
 
                 return redirect("costs")
 
@@ -617,8 +621,10 @@ def entry_rates(request):
                     session_scenario.save()
 
                 else:
-                    session_scenario.adjusted_numbers = data
-                    session_scenario.save()
+                    # Check that the dataframe or series saved in the form is not empty, then save
+                    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
+                        session_scenario.adjusted_numbers = data
+                        session_scenario.save()
 
                 stats = PopulationStats(historic_data)
 
@@ -730,8 +736,10 @@ def exit_rates(request):
                     session_scenario.save()
 
                 else:
-                    session_scenario.adjusted_rates = data
-                    session_scenario.save()
+                    # Check that the dataframe or series saved in the form is not empty, then save
+                    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
+                        session_scenario.adjusted_rates = data
+                        session_scenario.save()
 
                 stats = PopulationStats(historic_data)
 
@@ -844,8 +852,10 @@ def transition_rates(request):
                     session_scenario.save()
 
                 else:
-                    session_scenario.adjusted_rates = data
-                    session_scenario.save()
+                    # Check that the dataframe or series saved in the form is not empty, then save
+                    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
+                        session_scenario.adjusted_rates = data
+                        session_scenario.save()
 
                 stats = PopulationStats(historic_data)
 


### PR DESCRIPTION
This fixes the error created by saving an empty form and then navigating away.

The error was caused by the JSON decoder being unable to handle an empty dataframe. We could introduce code to enable the encoder to handle this, however this would likely lead to the empty dataframe causing further errors further down the chain. We should think about whether this is worth implementing despite the following fix.

Have implemented form to only save in initial instance (a user has not saved rates/numbers/proportions before) if the dataframe from the form is not empty.