### PR TITLE
104 cost page error

### DIFF
--- a/dm_regional_app/charts.py
+++ b/dm_regional_app/charts.py
@@ -128,32 +128,37 @@ def area_chart_population(historic_data: pd.DataFrame, prediction: CostForecast)
     return fig_html
 
 
-def placement_proportion_table(historic_proportions, current_proportion: CostForecast):
+def placement_proportion_table(historic_proportions, forecast_proportion: CostForecast):
     categories = {item.value.label: item.value.category.label for item in Costs}
 
-    current_proportion = current_proportion.proportions.sort_index()
+    forecast_proportion = forecast_proportion.proportions.sort_index()
     historic_proportions = historic_proportions.sort_index()
 
-    placement = current_proportion.index.map(categories)
+    # Align the series with a left join to retain all indices from forecast_proportion
+    forecast_proportion, historic_proportions = forecast_proportion.align(
+        historic_proportions, join="left", fill_value=0
+    )
 
-    if historic_proportions.equals(current_proportion):
+    placement = forecast_proportion.index.map(categories)
+
+    if historic_proportions.equals(forecast_proportion):
         proportions = pd.DataFrame(
             {
                 "Placement": placement,
-                "Placement type": current_proportion.index,
-                "Historic proportion": current_proportion.values,
+                "Placement type": forecast_proportion.index,
+                "Historic proportion": forecast_proportion.values,
             },
-            index=current_proportion.index,
+            index=forecast_proportion.index,
         )
     else:
         proportions = pd.DataFrame(
             {
                 "Placement": placement,
-                "Placement type": current_proportion.index,
+                "Placement type": forecast_proportion.index,
                 "Historic proportion": historic_proportions.values,
-                "Forecast proportion": current_proportion.values,
+                "Forecast proportion": forecast_proportion.values,
             },
-            index=current_proportion.index,
+            index=forecast_proportion.index,
         )
 
     proportions = proportions.sort_values(by=["Placement"])

--- a/dm_regional_app/views.py
+++ b/dm_regional_app/views.py
@@ -148,13 +148,14 @@ def costs(request):
 
         stats = PopulationStats(historic_data)
 
-        placement_proportions, historic_population = stats.placement_proportions(
-            **session_scenario.prediction_parameters
-        )
+        (
+            historic_placement_proportions,
+            historic_population,
+        ) = stats.placement_proportions(**session_scenario.prediction_parameters)
 
         costs = convert_population_to_cost(
             prediction,
-            placement_proportions,
+            historic_placement_proportions,
             session_scenario.adjusted_costs,
             session_scenario.adjusted_proportions,
             **session_scenario.inflation_parameters,
@@ -170,7 +171,7 @@ def costs(request):
 
         base_costs = convert_population_to_cost(
             base_prediction,
-            placement_proportions,
+            historic_placement_proportions,
             session_scenario.adjusted_costs,
             **session_scenario.inflation_parameters,
         )
@@ -186,7 +187,7 @@ def costs(request):
 
         area_costs = area_chart_cost(historic_costs, costs)
 
-        proportions = placement_proportion_table(placement_proportions, costs)
+        proportions = placement_proportion_table(historic_placement_proportions, costs)
 
         summary_table = summary_tables(costs.summary_table)
 
@@ -364,18 +365,19 @@ def placement_proportions(request):
 
         stats = PopulationStats(historic_data)
 
-        placement_proportions, historic_population = stats.placement_proportions(
-            **session_scenario.prediction_parameters
-        )
+        (
+            historic_placement_proportions,
+            historic_population,
+        ) = stats.placement_proportions(**session_scenario.prediction_parameters)
 
         costs = convert_population_to_cost(
             prediction,
-            placement_proportions,
+            historic_placement_proportions,
             session_scenario.adjusted_costs,
             session_scenario.adjusted_proportions,
         )
 
-        proportions = placement_proportion_table(placement_proportions, costs)
+        proportions = placement_proportion_table(historic_placement_proportions, costs)
 
         if request.method == "POST":
             form = DynamicForm(

--- a/ssda903/costs.py
+++ b/ssda903/costs.py
@@ -179,6 +179,8 @@ def convert_population_to_cost(
                         proportion = normalised_proportions[cost_item.label]
                     elif cost_item.label in historic_proportions.index:
                         proportion = historic_proportions[cost_item.label]
+                    else:
+                        proportion = 0
                     # add proportion to proportions output
                     proportions[cost_item.label] = proportion
 


### PR DESCRIPTION
placement_proportion_table was throwing an error due to historic and forecast proportions not being the same size - fixed via align/left join and fill (forecast proportions will always have ALL subcategories for any placementcategory in the historic data, but historic proportions only outputs the subcategories in historic data)

From here realised that costs has an error - subcategories not in data should be assigned 0 but this wasn't accounted for, has been adjusted.

Also renamed some proportions variables to increase code readability