### PR TITLE
feat: use middleware to replace router handler

### DIFF
--- a/dm_regional_app/middleware/scenario_middleware.py
+++ b/dm_regional_app/middleware/scenario_middleware.py
@@ -1,7 +1,17 @@
+import re
+
+from django.contrib import messages
+from django.shortcuts import redirect
+
 from dm_regional_app.models import DataSource, SessionScenario
 
 
 class SessionScenarioMiddleware:
+    PATHS_TO_IGNORE = re.compile(
+        r"(/admin.*)|(/accounts.*)|(/upload_data.*)|(/$)",
+        re.IGNORECASE,
+    )
+
     def __init__(self, get_response):
         self.get_response = get_response
 
@@ -9,7 +19,11 @@ class SessionScenarioMiddleware:
         # Initialise a SessionScenario
         session_scenario_id = request.session.get("session_scenario_id", None)
         current_user = request.user
-        if current_user.is_authenticated and DataSource.objects.exists():
+
+        if not current_user.is_authenticated:
+            return self.get_response(request)
+
+        if DataSource.objects.exists():
             historic_filters = {
                 "la": [],
                 "ethnicity": [],
@@ -49,7 +63,15 @@ class SessionScenarioMiddleware:
             )
 
             request.session["session_scenario_id"] = session_scenario.pk
+        else:
+            if self.PATHS_TO_IGNORE.match(request.path_info):
+                return self.get_response(request)
 
-        response = self.get_response(request)
+            messages.error(
+                request,
+                "There is no data available. If you are an admin, please upload data via Data Source Upload. Otherwise, "
+                "please contact your local admin.",
+            )
+            return redirect("home")
 
-        return response
+        return self.get_response(request)

--- a/dm_regional_app/middleware/scenario_middleware.py
+++ b/dm_regional_app/middleware/scenario_middleware.py
@@ -1,0 +1,55 @@
+from dm_regional_app.models import DataSource, SessionScenario
+
+
+class SessionScenarioMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Initialise a SessionScenario
+        session_scenario_id = request.session.get("session_scenario_id", None)
+        current_user = request.user
+        if current_user.is_authenticated and DataSource.objects.exists():
+            historic_filters = {
+                "la": [],
+                "ethnicity": [],
+                "sex": "all",
+                "uasc": "all",
+            }
+
+            data = DataSource.objects.latest("uploaded")
+            prediction_parameters = {
+                "reference_start_date": data.start_date,
+                "reference_end_date": data.end_date,
+                "prediction_start_date": None,
+                "prediction_end_date": None,
+            }
+            historic_stock = {
+                "population": {},
+                "base_rates": [],
+            }
+            inflation_parameters = {
+                "inflation": False,
+                "inflation_rate": 0.1,
+            }
+
+            # default_values should define the model default parameters
+            session_scenario, created = SessionScenario.objects.get_or_create(
+                id=session_scenario_id,
+                defaults={
+                    "user_id": current_user.id,
+                    "historic_filters": historic_filters,
+                    "prediction_parameters": prediction_parameters,
+                    "historic_stock": historic_stock,
+                    "adjusted_costs": None,
+                    "adjusted_rates": None,
+                    "adjusted_proportions": None,
+                    "inflation_parameters": inflation_parameters,
+                },
+            )
+
+            request.session["session_scenario_id"] = session_scenario.pk
+
+        response = self.get_response(request)
+
+        return response

--- a/dm_regional_app/templates/dm_regional_app/includes/authenticated_home.html
+++ b/dm_regional_app/templates/dm_regional_app/includes/authenticated_home.html
@@ -39,7 +39,7 @@
                     <p class="card-text">Check historic data from the SSDA903.</p>
                     <p class="card-text">You can filter to focus on a particular population.</p>
                     <p class="card-text"><i>Time required to complete: 3-5 minutes.</i></p>
-                    <a href="{% url 'router_handler' %}?next_url_name=historic_data" class="btn btn-primary">Start here</a>
+                    <a href="{% url 'historic_data' %}" class="btn btn-primary">Start here</a>
                     </div>
                 </div>
             </div>
@@ -57,7 +57,7 @@
                         </ul>
                         <i>Time required to complete: 4-7 minutes</i>
                     </p>
-                    <a href="{% url 'router_handler' %}?next_url_name=prediction" class="btn btn-primary">Start here</a>
+                    <a href="{% url 'prediction' %}" class="btn btn-primary">Start here</a>
                     </div>
                 </div>
             </div>
@@ -85,7 +85,7 @@
                     <div class="card-body">
                     <p class="card-text">Search and load scenarios that have been previously saved by yourself or colleagues at your Local Authority.</p>
                     <p class="card-text"><i>Time required to complete: 2-5 minutes</i></p>
-                    <a href="{% url 'router_handler' %}?next_url_name=scenarios" class="btn btn-primary">Start here</a>
+                    <a href="{% url 'scenarios' %}" class="btn btn-primary">Start here</a>
                     </div>
                 </div>
             </div>    
@@ -93,5 +93,5 @@
     </div>
 
     <div class="d-flex bd-highlight mb-3">
-        <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name=historic_data">Next</a></div>
+        <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'historic_data' %}">Next</a></div>
       </div>

--- a/dm_regional_app/templates/dm_regional_app/includes/navbar.html
+++ b/dm_regional_app/templates/dm_regional_app/includes/navbar.html
@@ -16,10 +16,10 @@
         {% if user.is_authenticated %}
           {% include 'dm_regional_app/includes/navbar-item.html' with url='home' name='Home' url_names="['home']" %}
           {% include 'dm_regional_app/includes/navbar-item.html' with url='scenarios' name='Saved Scenarios' url_names="['scenarios', 'scenario_detail']" %}
-          {% include 'dm_regional_app/includes/navbar-item.html' with url='router_handler' query="next_url_name=historic_data" name='Historic Data' url_names="['historic_data']" %}
-          {% include 'dm_regional_app/includes/navbar-item.html' with url='router_handler' query="next_url_name=prediction" name='Start Modelling' url_names="['prediction']" %}
-          {% include 'dm_regional_app/includes/navbar-item.html' with url='router_handler' query="next_url_name=adjusted" name='Adjust Forecast' url_names="['adjusted']" %}
-          {% include 'dm_regional_app/includes/navbar-item.html' with url='router_handler' query="next_url_name=costs" name='Projecting Spend' url_names="['costs']" %}
+          {% include 'dm_regional_app/includes/navbar-item.html' with url='historic_data' name='Historic Data' url_names="['historic_data']" %}
+          {% include 'dm_regional_app/includes/navbar-item.html' with url='prediction' name='Start Modelling' url_names="['prediction']" %}
+          {% include 'dm_regional_app/includes/navbar-item.html' with url='adjusted' name='Adjust Forecast' url_names="['adjusted']" %}
+          {% include 'dm_regional_app/includes/navbar-item.html' with url='costs' name='Projecting Spend' url_names="['costs']" %}
           {% get_social_accounts user as accounts %}
           {% if user.is_staff and accounts %}
                 {% include 'dm_regional_app/includes/navbar-item.html' with url='upload_data' name='Data Source Upload' url_names="['upload_data']" %}

--- a/dm_regional_app/templates/dm_regional_app/views/adjusted.html
+++ b/dm_regional_app/templates/dm_regional_app/views/adjusted.html
@@ -100,7 +100,7 @@
                                </table>
                                <div class="d-flex bd-highlight mb-3">
                                 <div class="p-2 bd-highlight"><a class="btn btn-warning" href="{% url 'clear_rates' %}?next_url_name=adjusted">Clear all rate adjustments</a></div>
-                                <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name=transition_rates">Edit this table</a></div>
+                                <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'transition_rates' %}">Edit this table</a></div>
                               </div>
                             </div>
                         </div>
@@ -116,9 +116,9 @@
     </div>
 
       <div class="d-flex bd-highlight mb-3">
-        <div class="p-2 bd-highlight"><a class="btn btn-secondary" href="{% url 'router_handler' %}?next_url_name=prediction">Back</a></div>
+        <div class="p-2 bd-highlight"><a class="btn btn-secondary" href="{% url 'prediction' %}">Back</a></div>
 
-        <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name=costs">Next</a></div>
+        <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'costs' %}">Next</a></div>
       </div>
     </div>
 {% endif %}

--- a/dm_regional_app/templates/dm_regional_app/views/costs.html
+++ b/dm_regional_app/templates/dm_regional_app/views/costs.html
@@ -87,7 +87,7 @@
             </div>
             {{ historic_filters | filter_text | safe}}
             <div class="d-flex bd-highlight mb-3">
-                <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name=prediction">Return to base forecast</a></div>
+                <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'prediction' %}">Return to base forecast</a></div>
               </div>
             </div>
 
@@ -121,7 +121,7 @@
                         <p>Only rate changes are shown on this page. To view all the rates affecting your forecast and make further changes please return to the adjusted forecast.</p>
                         <p>Please note that editing these tables will return you to the adjust forecast page.</p>
                         <div class="d-flex bd-highlight mb-3">
-                            <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name=adjusted">Return to adjust forecast</a></div>
+                            <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'adjusted' %}">Return to adjust forecast</a></div>
                           </div>
                         
                         <div class="accordion-group">
@@ -164,7 +164,7 @@
                                        </table>
                                        <div class="d-flex bd-highlight mb-3">
                                         <div class="p-2 bd-highlight"><a class="btn btn-warning" href="{% url 'clear_rates' %}?next_url_name=costs">Clear all rate adjustments</a></div>
-                                        <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name=transition_rates">Edit this table</a></div>
+                                        <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'transition_rates' %}">Edit this table</a></div>
                                       </div>
                                     </div>
                                 </div>
@@ -198,7 +198,7 @@
                     </table>
                 </div>
                 <div class="d-flex bd-highlight mb-3">
-                    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name=weekly_costs">Edit weekly costs</a></div>
+                    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'weekly_costs' %}">Edit weekly costs</a></div>
                   </div>
 
                   <div class="card">
@@ -250,7 +250,7 @@
                       </div>
                       {% endif %}
                         <div class="ms-auto p-2 bd-highlight">
-                          <a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name=placement_proportions">Edit placement proportions</a>
+                          <a class="btn btn-primary" href="{% url 'placement_proportions' %}">Edit placement proportions</a>
                         </div>
                       </div>
                     </div>
@@ -336,7 +336,7 @@
   </div>
 
       <div class="d-flex bd-highlight mb-3">
-        <div class="p-2 bd-highlight"><a class="btn btn-secondary" href="{% url 'router_handler' %}?next_url_name=adjusted">Back</a></div>
+        <div class="p-2 bd-highlight"><a class="btn btn-secondary" href="{% url 'adjusted' %}">Back</a></div>
       </div>
 
 {% endblock %}

--- a/dm_regional_app/templates/dm_regional_app/views/entry_rates.html
+++ b/dm_regional_app/templates/dm_regional_app/views/entry_rates.html
@@ -42,7 +42,7 @@
 
 <div class="d-flex bd-highlight mb-3">
     <div class="p-2 bd-highlight"><a class="btn btn-warning" href="{% url 'clear_rates' %}?next_url_name={{rate_change_origin_page}}">Clear all rate adjustments</a></div>
-    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name={{rate_change_origin_page}}">
+    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{{rate_change_origin_page}}">
         {% if rate_change_origin_page == '/costs' %}
             Return to projecting spend
         {% elif rate_change_origin_page == '/adjusted' %}

--- a/dm_regional_app/templates/dm_regional_app/views/exit_rates.html
+++ b/dm_regional_app/templates/dm_regional_app/views/exit_rates.html
@@ -44,7 +44,7 @@
 
 <div class="d-flex bd-highlight mb-3">
     <div class="p-2 bd-highlight"><a class="btn btn-warning" href="{% url 'clear_rates' %}?next_url_name={{rate_change_origin_page}}">Clear all rate adjustments</a></div>
-    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name={{rate_change_origin_page}}">
+    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{{rate_change_origin_page}}">
         {% if rate_change_origin_page == '/costs' %}
             Return to projecting spend
         {% elif rate_change_origin_page == '/adjusted' %}

--- a/dm_regional_app/templates/dm_regional_app/views/historic.html
+++ b/dm_regional_app/templates/dm_regional_app/views/historic.html
@@ -27,6 +27,6 @@
     {{chart|safe}}
 </div>
 <div class="d-flex bd-highlight mb-3">
-    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name=prediction">Next</a></div>
+    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'prediction' %}">Next</a></div>
   </div>
 {% endblock %}

--- a/dm_regional_app/templates/dm_regional_app/views/prediction.html
+++ b/dm_regional_app/templates/dm_regional_app/views/prediction.html
@@ -45,8 +45,8 @@
 </div>
 
 <div class="d-flex bd-highlight mb-3">
-    <div class="p-2 bd-highlight"><a class="btn btn-secondary" href="{% url 'router_handler' %}?next_url_name=historic_data">Back</a></div>
-    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name=adjusted">Next</a></div>
+    <div class="p-2 bd-highlight"><a class="btn btn-secondary" href="{% url 'historic_data' %}">Back</a></div>
+    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'adjusted' %}">Next</a></div>
   </div>
 
 {% endif %}

--- a/dm_regional_app/templates/dm_regional_app/views/transition_rates.html
+++ b/dm_regional_app/templates/dm_regional_app/views/transition_rates.html
@@ -40,7 +40,7 @@
 
 <div class="d-flex bd-highlight mb-3">
     <div class="p-2 bd-highlight"><a class="btn btn-warning" href="{% url 'clear_rates' %}?next_url_name={{rate_change_origin_page}}">Clear all rate adjustments</a></div>
-    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{% url 'router_handler' %}?next_url_name={{rate_change_origin_page}}">
+    <div class="ms-auto p-2 bd-highlight"><a class="btn btn-primary" href="{{rate_change_origin_page}}">
         {% if rate_change_origin_page == '/costs' %}
             Return to projecting spend
         {% elif rate_change_origin_page == '/adjusted' %}

--- a/dm_regional_app/tests/test_data_upload.py
+++ b/dm_regional_app/tests/test_data_upload.py
@@ -59,7 +59,7 @@ class DataUploadTestCase(TestCase):
             "uasc": SimpleUploadedFile("uasc.csv", b"uasc"),
         }
 
-        # Mock the datacontainer created from the uploaded files
+        # Mock the datacontainer created from the verifying the uploaded files
         datacontainer = MagicMock()
         type(datacontainer).start_date = datetime(2024, 1, 1)
         type(datacontainer).end_date = datetime(2024, 12, 1)

--- a/dm_regional_app/tests/test_scenario_detail_view.py
+++ b/dm_regional_app/tests/test_scenario_detail_view.py
@@ -1,9 +1,15 @@
-from django.test import TestCase
+from django.test import TestCase, modify_settings
 from django.urls import reverse
 
 from dm_regional_app.builder import Builder
 
 
+# Remove the custom middleware that checks for a DataSource as that is not the intention of this test suite
+@modify_settings(
+    MIDDLEWARE={
+        "remove": "dm_regional_app.middleware.scenario_middleware.SessionScenarioMiddleware"
+    }
+)
 class ScenarioDetailViewTestCase(TestCase):
     builder = Builder()
 

--- a/dm_regional_app/tests/test_scenarios_view.py
+++ b/dm_regional_app/tests/test_scenarios_view.py
@@ -1,9 +1,15 @@
-from django.test import TestCase
+from django.test import TestCase, modify_settings
 from django.urls import reverse
 
 from dm_regional_app.builder import Builder
 
 
+# Remove the custom middleware that checks for a DataSource as that is not the intention of this test suite
+@modify_settings(
+    MIDDLEWARE={
+        "remove": "dm_regional_app.middleware.scenario_middleware.SessionScenarioMiddleware"
+    }
+)
 class ScenariosTestCase(TestCase):
     builder = Builder()
 

--- a/dm_regional_app/urls.py
+++ b/dm_regional_app/urls.py
@@ -8,7 +8,6 @@ urlpatterns = [
     path("scenario/<int:pk>", views.scenario_detail, name="scenario_detail"),
     path("scenarios", views.scenarios, name="scenarios"),
     path("historic_data/", views.historic_data, name="historic_data"),
-    path("router_handler", views.router_handler, name="router_handler"),
     path("adjusted", views.adjusted, name="adjusted"),
     path("transition_rates", views.transition_rates, name="transition_rates"),
     path("exit_rates", views.exit_rates, name="exit_rates"),
@@ -29,5 +28,4 @@ urlpatterns = [
         name="clear_proportions",
     ),
     path("upload_data/", views.upload_data_source, name="upload_data"),
-
 ]

--- a/dm_regional_app/views.py
+++ b/dm_regional_app/views.py
@@ -131,320 +131,289 @@ def router_handler(request):
 
 @login_required
 def costs(request):
-    if "session_scenario_id" in request.session:
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
 
-        # Used to return user to this page when accessing rate change pages
-        request.session["rate_change_origin_page"] = reverse("costs")
+    # Used to return user to this page when accessing rate change pages
+    request.session["rate_change_origin_page"] = reverse("costs")
 
-        if request.method == "POST":
-            form = InflationForm(request.POST)
-            if form.is_valid():
-                session_scenario.inflation_parameters = form.cleaned_data
-                session_scenario.save()
+    if request.method == "POST":
+        form = InflationForm(request.POST)
+        if form.is_valid():
+            session_scenario.inflation_parameters = form.cleaned_data
+            session_scenario.save()
 
-        else:
-            inflation_parameters = session_scenario.inflation_parameters.copy()
-            form = InflationForm(initial=inflation_parameters)
+    else:
+        inflation_parameters = session_scenario.inflation_parameters.copy()
+        form = InflationForm(initial=inflation_parameters)
 
-        # read data
-        datacontainer = read_data(source=settings.DATA_SOURCE)
+    # read data
+    datacontainer = read_data(source=settings.DATA_SOURCE)
 
-        historic_data = apply_filters(
-            datacontainer.enriched_view, session_scenario.historic_filters
+    historic_data = apply_filters(
+        datacontainer.enriched_view, session_scenario.historic_filters
+    )
+
+    historic_filters = session_scenario.historic_filters
+
+    # Call predict function
+    prediction = predict(
+        data=historic_data,
+        **session_scenario.prediction_parameters,
+        rate_adjustment=session_scenario.adjusted_rates,
+        number_adjustment=session_scenario.adjusted_numbers,
+    )
+
+    stats = PopulationStats(historic_data)
+
+    (
+        historic_placement_proportions,
+        historic_population,
+    ) = stats.placement_proportions(**session_scenario.prediction_parameters)
+
+    costs = convert_population_to_cost(
+        prediction,
+        historic_placement_proportions,
+        session_scenario.adjusted_costs,
+        session_scenario.adjusted_proportions,
+        **session_scenario.inflation_parameters,
+    )
+
+    historic_costs = convert_historic_population_to_cost(
+        historic_population, session_scenario.adjusted_costs
+    )
+
+    base_prediction = predict(
+        data=historic_data, **session_scenario.prediction_parameters
+    )
+
+    base_costs = convert_population_to_cost(
+        base_prediction,
+        historic_placement_proportions,
+        session_scenario.adjusted_costs,
+        **session_scenario.inflation_parameters,
+    )
+
+    weekly_cost = pd.DataFrame(
+        {
+            "Placement type": costs.cost_summary.index,
+            "Weekly cost": costs.cost_summary.values,
+        }
+    )
+
+    area_numbers = area_chart_population(historic_population, costs)
+
+    area_costs = area_chart_cost(historic_costs, costs)
+
+    proportions = placement_proportion_table(historic_placement_proportions, costs)
+
+    summary_table = summary_tables(costs.summary_table)
+
+    summary_table_base = summary_tables(base_costs.summary_table)
+
+    summary_table_difference = summary_table - summary_table_base
+    summary_table_difference = summary_table_difference.round(2)
+
+    year_one_cost = year_one_costs(costs)
+    year_one_cost_base = year_one_costs(base_costs)
+    year_one_cost_difference = year_one_cost - year_one_cost_base
+    year_one_cost = number_format(year_one_cost)
+    year_one_cost_base = number_format(year_one_cost_base)
+    year_one_cost_difference = number_format(year_one_cost_difference)
+
+    if session_scenario.adjusted_rates is not None:
+        transition_rate_table = transition_rate_changes(
+            base_prediction.transition_rates, prediction.transition_rates
         )
-
-        historic_filters = session_scenario.historic_filters
-
-        # Call predict function
-        prediction = predict(
-            data=historic_data,
-            **session_scenario.prediction_parameters,
-            rate_adjustment=session_scenario.adjusted_rates,
-            number_adjustment=session_scenario.adjusted_numbers,
-        )
-
-        stats = PopulationStats(historic_data)
-
-        (
-            historic_placement_proportions,
-            historic_population,
-        ) = stats.placement_proportions(**session_scenario.prediction_parameters)
-
-        costs = convert_population_to_cost(
-            prediction,
-            historic_placement_proportions,
-            session_scenario.adjusted_costs,
-            session_scenario.adjusted_proportions,
-            **session_scenario.inflation_parameters,
-        )
-
-        historic_costs = convert_historic_population_to_cost(
-            historic_population, session_scenario.adjusted_costs
-        )
-
-        base_prediction = predict(
-            data=historic_data, **session_scenario.prediction_parameters
-        )
-
-        base_costs = convert_population_to_cost(
-            base_prediction,
-            historic_placement_proportions,
-            session_scenario.adjusted_costs,
-            **session_scenario.inflation_parameters,
-        )
-
-        weekly_cost = pd.DataFrame(
-            {
-                "Placement type": costs.cost_summary.index,
-                "Weekly cost": costs.cost_summary.values,
-            }
-        )
-
-        area_numbers = area_chart_population(historic_population, costs)
-
-        area_costs = area_chart_cost(historic_costs, costs)
-
-        proportions = placement_proportion_table(historic_placement_proportions, costs)
-
-        summary_table = summary_tables(costs.summary_table)
-
-        summary_table_base = summary_tables(base_costs.summary_table)
-
-        summary_table_difference = summary_table - summary_table_base
-        summary_table_difference = summary_table_difference.round(2)
-
-        year_one_cost = year_one_costs(costs)
-        year_one_cost_base = year_one_costs(base_costs)
-        year_one_cost_difference = year_one_cost - year_one_cost_base
-        year_one_cost = number_format(year_one_cost)
-        year_one_cost_base = number_format(year_one_cost_base)
-        year_one_cost_difference = number_format(year_one_cost_difference)
-
-        if session_scenario.adjusted_rates is not None:
-            transition_rate_table = transition_rate_changes(
-                base_prediction.transition_rates, prediction.transition_rates
-            )
-            exit_rate_table = exit_rate_changes(
-                base_prediction.transition_rates, prediction.transition_rates
-            )
-        else:
-            transition_rate_table = None
-            exit_rate_table = None
-
-        if session_scenario.adjusted_numbers is not None:
-            entry_rate_table = entry_rate_changes(
-                base_prediction.entry_rates, prediction.entry_rates
-            )
-        else:
-            entry_rate_table = None
-
-        return render(
-            request,
-            "dm_regional_app/views/costs.html",
-            {
-                "forecast_dates": session_scenario.prediction_parameters,
-                "weekly_cost": weekly_cost,
-                "proportions": proportions,
-                "area_numbers": area_numbers,
-                "area_costs": area_costs,
-                "summary_table": summary_table,
-                "summary_table_base": summary_table_base,
-                "summary_table_difference": summary_table_difference,
-                "year_one_cost": year_one_cost,
-                "year_one_cost_base": year_one_cost_base,
-                "year_one_cost_difference": year_one_cost_difference,
-                "historic_filters": historic_filters,
-                "transition_rate_table": transition_rate_table,
-                "exit_rate_table": exit_rate_table,
-                "entry_rate_table": entry_rate_table,
-                "form": form,
-            },
+        exit_rate_table = exit_rate_changes(
+            base_prediction.transition_rates, prediction.transition_rates
         )
     else:
-        next_url_name = "router_handler"
-        # Construct the URL for the router handler view and append the next_url_name as a query parameter
-        redirect_url = reverse(next_url_name) + "?next_url_name=" + "costs"
-        return redirect(redirect_url)
+        transition_rate_table = None
+        exit_rate_table = None
+
+    if session_scenario.adjusted_numbers is not None:
+        entry_rate_table = entry_rate_changes(
+            base_prediction.entry_rates, prediction.entry_rates
+        )
+    else:
+        entry_rate_table = None
+
+    return render(
+        request,
+        "dm_regional_app/views/costs.html",
+        {
+            "forecast_dates": session_scenario.prediction_parameters,
+            "weekly_cost": weekly_cost,
+            "proportions": proportions,
+            "area_numbers": area_numbers,
+            "area_costs": area_costs,
+            "summary_table": summary_table,
+            "summary_table_base": summary_table_base,
+            "summary_table_difference": summary_table_difference,
+            "year_one_cost": year_one_cost,
+            "year_one_cost_base": year_one_cost_base,
+            "year_one_cost_difference": year_one_cost_difference,
+            "historic_filters": historic_filters,
+            "transition_rate_table": transition_rate_table,
+            "exit_rate_table": exit_rate_table,
+            "entry_rate_table": entry_rate_table,
+            "form": form,
+        },
+    )
 
 
 @login_required
 def save_scenario(request):
-    if "session_scenario_id" in request.session:
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
-        current_user = request.user
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    current_user = request.user
 
-        if (
-            session_scenario.saved_scenario
-            and session_scenario.saved_scenario.user == current_user
-        ):
-            related_scenario = True
-            scenario_to_update = session_scenario.saved_scenario
-            form = SavedScenarioForm(instance=scenario_to_update)
+    if (
+        session_scenario.saved_scenario
+        and session_scenario.saved_scenario.user == current_user
+    ):
+        related_scenario = True
+        scenario_to_update = session_scenario.saved_scenario
+        form = SavedScenarioForm(instance=scenario_to_update)
+
+    else:
+        related_scenario = False
+        form = SavedScenarioForm()
+
+    if request.method == "POST":
+        if "update" in request.POST:
+            form = SavedScenarioForm(request.POST, instance=scenario_to_update)
+
+            if form.is_valid():
+                # Convert the session scenario to a dictionary, excluding fields you don't want to copy
+                session_data = model_to_dict(
+                    session_scenario, exclude=["id", "saved_scenario", "user"]
+                )
+
+                for key, value in session_data.items():
+                    setattr(scenario_to_update, key, value)
+
+                # Update with additional fields from the form
+                scenario_to_update.name = form.cleaned_data["name"]
+                scenario_to_update.description = form.cleaned_data["description"]
+                scenario_to_update.save()
+
+                messages.success(request, "Scenario updated.")
+
+                return redirect("scenarios")
 
         else:
-            related_scenario = False
-            form = SavedScenarioForm()
+            form = SavedScenarioForm(request.POST)
 
-        if request.method == "POST":
-            if "update" in request.POST:
-                form = SavedScenarioForm(request.POST, instance=scenario_to_update)
+            if form.is_valid():
+                # Convert the session scenario to a dictionary, excluding fields you don't want to copy
+                session_data = model_to_dict(
+                    session_scenario, exclude=["id", "saved_scenario", "user"]
+                )
 
-                if form.is_valid():
-                    # Convert the session scenario to a dictionary, excluding fields you don't want to copy
-                    session_data = model_to_dict(
-                        session_scenario, exclude=["id", "saved_scenario", "user"]
-                    )
+                # Create the SavedScenario instance
+                saved_scenario = SavedScenario.objects.create(
+                    **session_data, user_id=current_user.id
+                )
 
-                    for key, value in session_data.items():
-                        setattr(scenario_to_update, key, value)
+                # Update with additional fields from the form
+                saved_scenario.name = form.cleaned_data["name"]
+                saved_scenario.description = form.cleaned_data["description"]
+                saved_scenario.save()
 
-                    # Update with additional fields from the form
-                    scenario_to_update.name = form.cleaned_data["name"]
-                    scenario_to_update.description = form.cleaned_data["description"]
-                    scenario_to_update.save()
+                # Associate the saved scenario with the session scenario
+                session_scenario.saved_scenario = saved_scenario
+                session_scenario.save()
 
-                    messages.success(request, "Scenario updated.")
+                messages.success(request, "Scenario saved.")
 
-                    return redirect("scenarios")
+                return redirect("scenarios")
 
-            else:
-                form = SavedScenarioForm(request.POST)
-
-                if form.is_valid():
-                    # Convert the session scenario to a dictionary, excluding fields you don't want to copy
-                    session_data = model_to_dict(
-                        session_scenario, exclude=["id", "saved_scenario", "user"]
-                    )
-
-                    # Create the SavedScenario instance
-                    saved_scenario = SavedScenario.objects.create(
-                        **session_data, user_id=current_user.id
-                    )
-
-                    # Update with additional fields from the form
-                    saved_scenario.name = form.cleaned_data["name"]
-                    saved_scenario.description = form.cleaned_data["description"]
-                    saved_scenario.save()
-
-                    # Associate the saved scenario with the session scenario
-                    session_scenario.saved_scenario = saved_scenario
-                    session_scenario.save()
-
-                    messages.success(request, "Scenario saved.")
-
-                    return redirect("scenarios")
-
-        return render(
-            request,
-            "dm_regional_app/views/save_scenario.html",
-            {
-                "form": form,
-                "related_scenario": related_scenario,
-            },
-        )
-    else:
-        next_url_name = "router_handler"
-        # Construct the URL for the router handler view and append the next_url_name as a query parameter
-        redirect_url = reverse(next_url_name) + "?next_url_name=" + "save_scenario"
-        return redirect(redirect_url)
+    return render(
+        request,
+        "dm_regional_app/views/save_scenario.html",
+        {
+            "form": form,
+            "related_scenario": related_scenario,
+        },
+    )
 
 
 @login_required
 def clear_proportion_adjustments(request):
-    if "session_scenario_id" in request.session:
-        # get next url page
-        next_url_name = request.GET.get("next_url_name")
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
-        session_scenario.adjusted_proportions = None
-        session_scenario.save()
-        messages.success(request, "Proportion adjustments cleared.")
+    # get next url page
+    next_url_name = request.GET.get("next_url_name")
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    session_scenario.adjusted_proportions = None
+    session_scenario.save()
+    messages.success(request, "Proportion adjustments cleared.")
     return redirect(next_url_name)
 
 
 @login_required
 def placement_proportions(request):
-    if "session_scenario_id" in request.session:
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
-        # read data
-        datacontainer = read_data(source=settings.DATA_SOURCE)
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    # read data
+    datacontainer = read_data(source=settings.DATA_SOURCE)
 
-        historic_data = apply_filters(
-            datacontainer.enriched_view, session_scenario.historic_filters
+    historic_data = apply_filters(
+        datacontainer.enriched_view, session_scenario.historic_filters
+    )
+
+    # Call predict function
+    prediction = predict(data=historic_data, **session_scenario.prediction_parameters)
+
+    stats = PopulationStats(historic_data)
+
+    (
+        historic_placement_proportions,
+        historic_population,
+    ) = stats.placement_proportions(**session_scenario.prediction_parameters)
+
+    costs = convert_population_to_cost(
+        prediction,
+        historic_placement_proportions,
+        session_scenario.adjusted_costs,
+        session_scenario.adjusted_proportions,
+    )
+
+    proportions = placement_proportion_table(historic_placement_proportions, costs)
+
+    if request.method == "POST":
+        form = DynamicForm(
+            request.POST,
+            dataframe=costs.proportions,
+            initial_data=session_scenario.adjusted_proportions,
         )
+        if form.is_valid():
+            data = form.save()
 
-        # Call predict function
-        prediction = predict(
-            data=historic_data, **session_scenario.prediction_parameters
-        )
+            if session_scenario.adjusted_proportions is not None:
+                # if previous proportion adjustments have been made, update old series with new adjustments
+                proportion_adjustments = session_scenario.adjusted_proportions
+                new_numbers = data.combine_first(proportion_adjustments)
 
-        stats = PopulationStats(historic_data)
+                session_scenario.adjusted_proportions = new_numbers
+                session_scenario.save()
 
-        (
-            historic_placement_proportions,
-            historic_population,
-        ) = stats.placement_proportions(**session_scenario.prediction_parameters)
+            else:
+                # Check that the dataframe or series saved in the form is not empty, then save
+                if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
+                    session_scenario.adjusted_proportions = data
+                    session_scenario.save()
 
-        costs = convert_population_to_cost(
-            prediction,
-            historic_placement_proportions,
-            session_scenario.adjusted_costs,
-            session_scenario.adjusted_proportions,
-        )
+            return redirect("costs")
 
-        proportions = placement_proportion_table(historic_placement_proportions, costs)
-
-        if request.method == "POST":
+        else:
             form = DynamicForm(
                 request.POST,
                 dataframe=costs.proportions,
                 initial_data=session_scenario.adjusted_proportions,
             )
-            if form.is_valid():
-                data = form.save()
-
-                if session_scenario.adjusted_proportions is not None:
-                    # if previous proportion adjustments have been made, update old series with new adjustments
-                    proportion_adjustments = session_scenario.adjusted_proportions
-                    new_numbers = data.combine_first(proportion_adjustments)
-
-                    session_scenario.adjusted_proportions = new_numbers
-                    session_scenario.save()
-
-                else:
-                    # Check that the dataframe or series saved in the form is not empty, then save
-                    if isinstance(data, (pd.DataFrame, pd.Series)) and not data.empty:
-                        session_scenario.adjusted_proportions = data
-                        session_scenario.save()
-
-                return redirect("costs")
-
-            else:
-                form = DynamicForm(
-                    request.POST,
-                    dataframe=costs.proportions,
-                    initial_data=session_scenario.adjusted_proportions,
-                )
-                messages.warning(request, "Form not saved, positive numbers only")
-
-                return render(
-                    request,
-                    "dm_regional_app/views/placement_proportions.html",
-                    {
-                        "form": form,
-                        "placement_types": proportions,
-                    },
-                )
-
-        else:
-            form = DynamicForm(
-                dataframe=costs.proportions,
-                initial_data=session_scenario.adjusted_proportions,
-            )
+            messages.warning(request, "Form not saved, positive numbers only")
 
             return render(
                 request,
@@ -454,89 +423,79 @@ def placement_proportions(request):
                     "placement_types": proportions,
                 },
             )
+
     else:
-        next_url_name = "router_handler"
-        # Construct the URL for the router handler view and append the next_url_name as a query parameter
-        redirect_url = (
-            reverse(next_url_name) + "?next_url_name=" + "placement_proportions"
+        form = DynamicForm(
+            dataframe=costs.proportions,
+            initial_data=session_scenario.adjusted_proportions,
         )
-        return redirect(redirect_url)
+
+        return render(
+            request,
+            "dm_regional_app/views/placement_proportions.html",
+            {
+                "form": form,
+                "placement_types": proportions,
+            },
+        )
 
 
 @login_required
 def weekly_costs(request):
-    if "session_scenario_id" in request.session:
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
-        # read data
-        datacontainer = read_data(source=settings.DATA_SOURCE)
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    # read data
+    datacontainer = read_data(source=settings.DATA_SOURCE)
 
-        historic_data = apply_filters(
-            datacontainer.enriched_view, session_scenario.historic_filters
+    historic_data = apply_filters(
+        datacontainer.enriched_view, session_scenario.historic_filters
+    )
+
+    # Call predict function
+    prediction = predict(data=historic_data, **session_scenario.prediction_parameters)
+
+    stats = PopulationStats(historic_data)
+
+    placement_proportions, historic_population = stats.placement_proportions(
+        **session_scenario.prediction_parameters
+    )
+
+    costs = convert_population_to_cost(
+        prediction,
+        placement_proportions,
+        session_scenario.adjusted_costs,
+        session_scenario.adjusted_proportions,
+    )
+
+    placement_types = pd.DataFrame(
+        {"Placement type": costs.cost_summary.index}, index=costs.cost_summary.index
+    )
+
+    if request.method == "POST":
+        form = DynamicForm(
+            request.POST,
+            dataframe=costs.cost_summary,
+            initial_data=costs.cost_summary,
         )
+        if form.is_valid():
+            data = form.save()
 
-        # Call predict function
-        prediction = predict(
-            data=historic_data, **session_scenario.prediction_parameters
-        )
+            if session_scenario.adjusted_costs is not None:
+                # if previous cost adjustments have been made, update old series with new adjustments
+                cost_adjustments = session_scenario.adjusted_costs
+                new_numbers = data.combine_first(cost_adjustments)
 
-        stats = PopulationStats(historic_data)
-
-        placement_proportions, historic_population = stats.placement_proportions(
-            **session_scenario.prediction_parameters
-        )
-
-        costs = convert_population_to_cost(
-            prediction,
-            placement_proportions,
-            session_scenario.adjusted_costs,
-            session_scenario.adjusted_proportions,
-        )
-
-        placement_types = pd.DataFrame(
-            {"Placement type": costs.cost_summary.index}, index=costs.cost_summary.index
-        )
-
-        if request.method == "POST":
-            form = DynamicForm(
-                request.POST,
-                dataframe=costs.cost_summary,
-                initial_data=costs.cost_summary,
-            )
-            if form.is_valid():
-                data = form.save()
-
-                if session_scenario.adjusted_costs is not None:
-                    # if previous cost adjustments have been made, update old series with new adjustments
-                    cost_adjustments = session_scenario.adjusted_costs
-                    new_numbers = data.combine_first(cost_adjustments)
-
-                    session_scenario.adjusted_costs = new_numbers
-                    session_scenario.save()
-
-                else:
-                    # Check that the dataframe or series saved in the form is not empty, then save
-                    save_data_if_not_empty(session_scenario, data, "adjusted_costs")
-
-                return redirect("costs")
+                session_scenario.adjusted_costs = new_numbers
+                session_scenario.save()
 
             else:
-                messages.warning(request, "Form not saved, positive numbers only")
-                return render(
-                    request,
-                    "dm_regional_app/views/weekly_costs.html",
-                    {
-                        "form": form,
-                        "placement_types": placement_types,
-                    },
-                )
+                # Check that the dataframe or series saved in the form is not empty, then save
+                save_data_if_not_empty(session_scenario, data, "adjusted_costs")
+
+            return redirect("costs")
 
         else:
-            form = DynamicForm(
-                dataframe=costs.cost_summary,
-                initial_data=costs.cost_summary,
-            )
-
+            messages.warning(request, "Form not saved, positive numbers only")
             return render(
                 request,
                 "dm_regional_app/views/weekly_costs.html",
@@ -545,11 +504,21 @@ def weekly_costs(request):
                     "placement_types": placement_types,
                 },
             )
+
     else:
-        next_url_name = "router_handler"
-        # Construct the URL for the router handler view and append the next_url_name as a query parameter
-        redirect_url = reverse(next_url_name) + "?next_url_name=" + "weekly_costs"
-        return redirect(redirect_url)
+        form = DynamicForm(
+            dataframe=costs.cost_summary,
+            initial_data=costs.cost_summary,
+        )
+
+        return render(
+            request,
+            "dm_regional_app/views/weekly_costs.html",
+            {
+                "form": form,
+                "placement_types": placement_types,
+            },
+        )
 
 
 @login_required
@@ -591,219 +560,184 @@ def load_saved_scenario(request, pk):
 
 @login_required
 def clear_rate_adjustments(request):
-    if "session_scenario_id" in request.session:
-        # get next url page
-        next_url_name = request.GET.get("next_url_name")
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
-        session_scenario.adjusted_rates = None
-        session_scenario.adjusted_numbers = None
-        session_scenario.save()
-        messages.success(request, "Rate adjustments cleared.")
+    # get next url page
+    next_url_name = request.GET.get("next_url_name")
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    session_scenario.adjusted_rates = None
+    session_scenario.adjusted_numbers = None
+    session_scenario.save()
+    messages.success(request, "Rate adjustments cleared.")
     return redirect(next_url_name)
 
 
 @login_required
 def entry_rates(request):
-    if "session_scenario_id" in request.session:
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
-        rate_change_origin_page = request.session["rate_change_origin_page"]
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    rate_change_origin_page = request.session["rate_change_origin_page"]
 
-        # read data
-        datacontainer = read_data(source=settings.DATA_SOURCE)
+    # read data
+    datacontainer = read_data(source=settings.DATA_SOURCE)
 
-        historic_data = apply_filters(
-            datacontainer.enriched_view, session_scenario.historic_filters
+    historic_data = apply_filters(
+        datacontainer.enriched_view, session_scenario.historic_filters
+    )
+
+    # Call predict function
+    prediction = predict(data=historic_data, **session_scenario.prediction_parameters)
+
+    entry_rates = entry_rate_table(prediction.entry_rates)
+
+    if request.method == "POST":
+        form = DynamicForm(
+            request.POST,
+            dataframe=prediction.entry_rates,
+            initial_data=session_scenario.adjusted_numbers,
         )
+        if form.is_valid():
+            data = form.save()
 
-        # Call predict function
-        prediction = predict(
-            data=historic_data, **session_scenario.prediction_parameters
-        )
+            if session_scenario.adjusted_numbers is not None:
+                # if previous rate adjustments have been made, update old series with new adjustments
+                rate_adjustments = session_scenario.adjusted_numbers
+                new_numbers = data.combine_first(rate_adjustments)
 
-        entry_rates = entry_rate_table(prediction.entry_rates)
+                session_scenario.adjusted_numbers = new_numbers
+                session_scenario.save()
 
-        if request.method == "POST":
+            else:
+                # Check that the dataframe or series saved in the form is not empty, then save
+                save_data_if_not_empty(session_scenario, data, "adjusted_numbers")
+
+            stats = PopulationStats(historic_data)
+
+            adjusted_prediction = predict(
+                data=historic_data,
+                **session_scenario.prediction_parameters,
+                rate_adjustment=session_scenario.adjusted_rates,
+                number_adjustment=session_scenario.adjusted_numbers,
+            )
+
+            # build chart
+            chart = compare_forecast(
+                stats,
+                prediction,
+                adjusted_prediction,
+                **session_scenario.prediction_parameters,
+            )
+
+            is_post = True
+
+            return render(
+                request,
+                "dm_regional_app/views/entry_rates.html",
+                {
+                    "entry_rate_table": entry_rates,
+                    "form": form,
+                    "chart": chart,
+                    "is_post": is_post,
+                    "rate_change_origin_page": rate_change_origin_page,
+                },
+            )
+        else:
+            messages.warning(request, "Form not saved, positive numbers only")
             form = DynamicForm(
                 request.POST,
-                dataframe=prediction.entry_rates,
-                initial_data=session_scenario.adjusted_numbers,
-            )
-            if form.is_valid():
-                data = form.save()
-
-                if session_scenario.adjusted_numbers is not None:
-                    # if previous rate adjustments have been made, update old series with new adjustments
-                    rate_adjustments = session_scenario.adjusted_numbers
-                    new_numbers = data.combine_first(rate_adjustments)
-
-                    session_scenario.adjusted_numbers = new_numbers
-                    session_scenario.save()
-
-                else:
-                    # Check that the dataframe or series saved in the form is not empty, then save
-                    save_data_if_not_empty(session_scenario, data, "adjusted_numbers")
-
-                stats = PopulationStats(historic_data)
-
-                adjusted_prediction = predict(
-                    data=historic_data,
-                    **session_scenario.prediction_parameters,
-                    rate_adjustment=session_scenario.adjusted_rates,
-                    number_adjustment=session_scenario.adjusted_numbers,
-                )
-
-                # build chart
-                chart = compare_forecast(
-                    stats,
-                    prediction,
-                    adjusted_prediction,
-                    **session_scenario.prediction_parameters,
-                )
-
-                is_post = True
-
-                return render(
-                    request,
-                    "dm_regional_app/views/entry_rates.html",
-                    {
-                        "entry_rate_table": entry_rates,
-                        "form": form,
-                        "chart": chart,
-                        "is_post": is_post,
-                        "rate_change_origin_page": rate_change_origin_page,
-                    },
-                )
-            else:
-                messages.warning(request, "Form not saved, positive numbers only")
-                form = DynamicForm(
-                    request.POST,
-                    initial_data=session_scenario.adjusted_numbers,
-                    dataframe=prediction.entry_rates,
-                )
-
-                is_post = False
-
-                return render(
-                    request,
-                    "dm_regional_app/views/entry_rates.html",
-                    {
-                        "entry_rate_table": entry_rates,
-                        "form": form,
-                        "is_post": is_post,
-                        "rate_change_origin_page": rate_change_origin_page,
-                    },
-                )
-
-        else:
-            form = DynamicForm(
                 initial_data=session_scenario.adjusted_numbers,
                 dataframe=prediction.entry_rates,
             )
 
             is_post = False
 
-        return render(
-            request,
-            "dm_regional_app/views/entry_rates.html",
-            {
-                "entry_rate_table": entry_rates,
-                "form": form,
-                "is_post": is_post,
-                "rate_change_origin_page": rate_change_origin_page,
-            },
-        )
+            return render(
+                request,
+                "dm_regional_app/views/entry_rates.html",
+                {
+                    "entry_rate_table": entry_rates,
+                    "form": form,
+                    "is_post": is_post,
+                    "rate_change_origin_page": rate_change_origin_page,
+                },
+            )
 
     else:
-        next_url_name = "router_handler"
-        # Construct the URL for the router handler view and append the next_url_name as a query parameter
-        redirect_url = reverse(next_url_name) + "?next_url_name=" + "entry_rates"
-        return redirect(redirect_url)
+        form = DynamicForm(
+            initial_data=session_scenario.adjusted_numbers,
+            dataframe=prediction.entry_rates,
+        )
+
+        is_post = False
+
+    return render(
+        request,
+        "dm_regional_app/views/entry_rates.html",
+        {
+            "entry_rate_table": entry_rates,
+            "form": form,
+            "is_post": is_post,
+            "rate_change_origin_page": rate_change_origin_page,
+        },
+    )
 
 
 @login_required
 def exit_rates(request):
-    if "session_scenario_id" in request.session:
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
-        rate_change_origin_page = request.session["rate_change_origin_page"]
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    rate_change_origin_page = request.session["rate_change_origin_page"]
 
-        # read data
-        datacontainer = read_data(source=settings.DATA_SOURCE)
+    # read data
+    datacontainer = read_data(source=settings.DATA_SOURCE)
 
-        historic_data = apply_filters(
-            datacontainer.enriched_view, session_scenario.historic_filters
+    historic_data = apply_filters(
+        datacontainer.enriched_view, session_scenario.historic_filters
+    )
+
+    # Call predict function
+    prediction = predict(data=historic_data, **session_scenario.prediction_parameters)
+
+    exit_rates = exit_rate_table(prediction.transition_rates)
+
+    if request.method == "POST":
+        form = DynamicForm(
+            request.POST,
+            dataframe=prediction.transition_rates,
+            initial_data=session_scenario.adjusted_rates,
         )
+        if form.is_valid():
+            data = form.save()
 
-        # Call predict function
-        prediction = predict(
-            data=historic_data, **session_scenario.prediction_parameters
-        )
+            if session_scenario.adjusted_rates is not None:
+                # if previous rate adjustments have been made, update old series with new adjustments
+                rate_adjustments = session_scenario.adjusted_rates
+                new_rates = data.combine_first(rate_adjustments)
 
-        exit_rates = exit_rate_table(prediction.transition_rates)
-
-        if request.method == "POST":
-            form = DynamicForm(
-                request.POST,
-                dataframe=prediction.transition_rates,
-                initial_data=session_scenario.adjusted_rates,
-            )
-            if form.is_valid():
-                data = form.save()
-
-                if session_scenario.adjusted_rates is not None:
-                    # if previous rate adjustments have been made, update old series with new adjustments
-                    rate_adjustments = session_scenario.adjusted_rates
-                    new_rates = data.combine_first(rate_adjustments)
-
-                    session_scenario.adjusted_rates = new_rates
-                    session_scenario.save()
-
-                else:
-                    # Check that the dataframe or series saved in the form is not empty, then save
-                    save_data_if_not_empty(session_scenario, data, "adjusted_rates")
-
-                stats = PopulationStats(historic_data)
-
-                adjusted_prediction = predict(
-                    data=historic_data,
-                    **session_scenario.prediction_parameters,
-                    rate_adjustment=session_scenario.adjusted_rates,
-                    number_adjustment=session_scenario.adjusted_numbers,
-                )
-
-                # build chart
-                chart = compare_forecast(
-                    stats,
-                    prediction,
-                    adjusted_prediction,
-                    **session_scenario.prediction_parameters,
-                )
-
-                is_post = True
-
-                return render(
-                    request,
-                    "dm_regional_app/views/exit_rates.html",
-                    {
-                        "exit_rate_table": exit_rates,
-                        "form": form,
-                        "chart": chart,
-                        "is_post": is_post,
-                        "rate_change_origin_page": rate_change_origin_page,
-                    },
-                )
+                session_scenario.adjusted_rates = new_rates
+                session_scenario.save()
 
             else:
-                form = DynamicForm(
-                    request.POST,
-                    initial_data=session_scenario.adjusted_rates,
-                    dataframe=prediction.transition_rates,
-                )
-                messages.warning(request, "Form not saved, positive numbers only")
+                # Check that the dataframe or series saved in the form is not empty, then save
+                save_data_if_not_empty(session_scenario, data, "adjusted_rates")
 
-                is_post = False
+            stats = PopulationStats(historic_data)
+
+            adjusted_prediction = predict(
+                data=historic_data,
+                **session_scenario.prediction_parameters,
+                rate_adjustment=session_scenario.adjusted_rates,
+                number_adjustment=session_scenario.adjusted_numbers,
+            )
+
+            # build chart
+            chart = compare_forecast(
+                stats,
+                prediction,
+                adjusted_prediction,
+                **session_scenario.prediction_parameters,
+            )
+
+            is_post = True
 
             return render(
                 request,
@@ -811,6 +745,7 @@ def exit_rates(request):
                 {
                     "exit_rate_table": exit_rates,
                     "form": form,
+                    "chart": chart,
                     "is_post": is_post,
                     "rate_change_origin_page": rate_change_origin_page,
                 },
@@ -818,9 +753,11 @@ def exit_rates(request):
 
         else:
             form = DynamicForm(
+                request.POST,
                 initial_data=session_scenario.adjusted_rates,
                 dataframe=prediction.transition_rates,
             )
+            messages.warning(request, "Form not saved, positive numbers only")
 
             is_post = False
 
@@ -834,95 +771,84 @@ def exit_rates(request):
                 "rate_change_origin_page": rate_change_origin_page,
             },
         )
+
     else:
-        next_url_name = "router_handler"
-        # Construct the URL for the router handler view and append the next_url_name as a query parameter
-        redirect_url = reverse(next_url_name) + "?next_url_name=" + "exit_rates"
-        return redirect(redirect_url)
+        form = DynamicForm(
+            initial_data=session_scenario.adjusted_rates,
+            dataframe=prediction.transition_rates,
+        )
+
+        is_post = False
+
+    return render(
+        request,
+        "dm_regional_app/views/exit_rates.html",
+        {
+            "exit_rate_table": exit_rates,
+            "form": form,
+            "is_post": is_post,
+            "rate_change_origin_page": rate_change_origin_page,
+        },
+    )
 
 
 @login_required
 def transition_rates(request):
-    if "session_scenario_id" in request.session:
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
-        rate_change_origin_page = request.session["rate_change_origin_page"]
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    rate_change_origin_page = request.session["rate_change_origin_page"]
 
-        # read data
-        datacontainer = read_data(source=settings.DATA_SOURCE)
+    # read data
+    datacontainer = read_data(source=settings.DATA_SOURCE)
 
-        historic_data = apply_filters(
-            datacontainer.enriched_view, session_scenario.historic_filters
+    historic_data = apply_filters(
+        datacontainer.enriched_view, session_scenario.historic_filters
+    )
+
+    # Call predict function
+    prediction = predict(data=historic_data, **session_scenario.prediction_parameters)
+
+    transition_rates = transition_rate_table(prediction.transition_rates)
+
+    if request.method == "POST":
+        form = DynamicForm(
+            request.POST,
+            dataframe=prediction.transition_rates,
+            initial_data=session_scenario.adjusted_rates,
         )
+        if form.is_valid():
+            data = form.save()
 
-        # Call predict function
-        prediction = predict(
-            data=historic_data, **session_scenario.prediction_parameters
-        )
+            if session_scenario.adjusted_rates is not None:
+                # if previous rate adjustments have been made, update old series with new adjustments
+                rate_adjustments = session_scenario.adjusted_rates
+                new_rates = data.combine_first(rate_adjustments)
 
-        transition_rates = transition_rate_table(prediction.transition_rates)
-
-        if request.method == "POST":
-            form = DynamicForm(
-                request.POST,
-                dataframe=prediction.transition_rates,
-                initial_data=session_scenario.adjusted_rates,
-            )
-            if form.is_valid():
-                data = form.save()
-
-                if session_scenario.adjusted_rates is not None:
-                    # if previous rate adjustments have been made, update old series with new adjustments
-                    rate_adjustments = session_scenario.adjusted_rates
-                    new_rates = data.combine_first(rate_adjustments)
-
-                    session_scenario.adjusted_rates = new_rates
-                    session_scenario.save()
-
-                else:
-                    # Check that the dataframe or series saved in the form is not empty, then save
-                    save_data_if_not_empty(session_scenario, data, "adjusted_rates")
-
-                stats = PopulationStats(historic_data)
-
-                adjusted_prediction = predict(
-                    data=historic_data,
-                    **session_scenario.prediction_parameters,
-                    rate_adjustment=session_scenario.adjusted_rates,
-                    number_adjustment=session_scenario.adjusted_numbers,
-                )
-
-                # build chart
-                chart = compare_forecast(
-                    stats,
-                    prediction,
-                    adjusted_prediction,
-                    **session_scenario.prediction_parameters,
-                )
-
-                is_post = True
-
-                return render(
-                    request,
-                    "dm_regional_app/views/transition_rates.html",
-                    {
-                        "transition_rate_table": transition_rates,
-                        "form": form,
-                        "chart": chart,
-                        "is_post": is_post,
-                        "rate_change_origin_page": rate_change_origin_page,
-                    },
-                )
+                session_scenario.adjusted_rates = new_rates
+                session_scenario.save()
 
             else:
-                form = DynamicForm(
-                    request.POST,
-                    initial_data=session_scenario.adjusted_rates,
-                    dataframe=prediction.transition_rates,
-                )
+                # Check that the dataframe or series saved in the form is not empty, then save
+                save_data_if_not_empty(session_scenario, data, "adjusted_rates")
 
-                is_post = False
-                messages.warning(request, "Form not saved, positive numbers only")
+            stats = PopulationStats(historic_data)
+
+            adjusted_prediction = predict(
+                data=historic_data,
+                **session_scenario.prediction_parameters,
+                rate_adjustment=session_scenario.adjusted_rates,
+                number_adjustment=session_scenario.adjusted_numbers,
+            )
+
+            # build chart
+            chart = compare_forecast(
+                stats,
+                prediction,
+                adjusted_prediction,
+                **session_scenario.prediction_parameters,
+            )
+
+            is_post = True
 
             return render(
                 request,
@@ -930,6 +856,7 @@ def transition_rates(request):
                 {
                     "transition_rate_table": transition_rates,
                     "form": form,
+                    "chart": chart,
                     "is_post": is_post,
                     "rate_change_origin_page": rate_change_origin_page,
                 },
@@ -937,11 +864,13 @@ def transition_rates(request):
 
         else:
             form = DynamicForm(
+                request.POST,
                 initial_data=session_scenario.adjusted_rates,
                 dataframe=prediction.transition_rates,
             )
 
             is_post = False
+            messages.warning(request, "Form not saved, positive numbers only")
 
         return render(
             request,
@@ -953,325 +882,319 @@ def transition_rates(request):
                 "rate_change_origin_page": rate_change_origin_page,
             },
         )
+
     else:
-        next_url_name = "router_handler"
-        # Construct the URL for the router handler view and append the next_url_name as a query parameter
-        redirect_url = reverse(next_url_name) + "?next_url_name=" + "transition_rates"
-        return redirect(redirect_url)
+        form = DynamicForm(
+            initial_data=session_scenario.adjusted_rates,
+            dataframe=prediction.transition_rates,
+        )
+
+        is_post = False
+
+    return render(
+        request,
+        "dm_regional_app/views/transition_rates.html",
+        {
+            "transition_rate_table": transition_rates,
+            "form": form,
+            "is_post": is_post,
+            "rate_change_origin_page": rate_change_origin_page,
+        },
+    )
 
 
 @login_required
 def adjusted(request):
-    if "session_scenario_id" in request.session:
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
 
-        # Used to return user to this page when accessing rate change pages
-        request.session["rate_change_origin_page"] = reverse("adjusted")
+    # Used to return user to this page when accessing rate change pages
+    request.session["rate_change_origin_page"] = reverse("adjusted")
 
-        # read data
-        datacontainer = read_data(source=settings.DATA_SOURCE)
+    # read data
+    datacontainer = read_data(source=settings.DATA_SOURCE)
 
-        if request.method == "POST":
-            # check if it was historic data filter form that was submitted
-            if "uasc" in request.POST:
-                historic_form = HistoricDataFilter(
-                    request.POST,
-                    la=datacontainer.unique_las,
-                    ethnicity=datacontainer.unique_ethnicity,
-                )
-                predict_form = PredictFilter(
-                    initial=session_scenario.prediction_parameters,
-                    start_date=datacontainer.start_date,
-                    end_date=datacontainer.end_date,
-                )
-                if historic_form.is_valid():
-                    session_scenario.historic_filters = historic_form.cleaned_data
-                    session_scenario.save()
-
-                    historic_data = apply_filters(
-                        datacontainer.enriched_view, historic_form.cleaned_data
-                    )
-
-            # check if it was predict filter form that was submitted
-            if "reference_start_date" in request.POST:
-                predict_form = PredictFilter(
-                    request.POST,
-                    start_date=datacontainer.start_date,
-                    end_date=datacontainer.end_date,
-                )
-                historic_form = HistoricDataFilter(
-                    initial=session_scenario.historic_filters,
-                    la=datacontainer.unique_las,
-                    ethnicity=datacontainer.unique_ethnicity,
-                )
-
-                historic_data = apply_filters(
-                    datacontainer.enriched_view, historic_form.initial
-                )
-                if predict_form.is_valid():
-                    session_scenario.prediction_parameters = predict_form.cleaned_data
-                    session_scenario.save()
-
-        else:
+    if request.method == "POST":
+        # check if it was historic data filter form that was submitted
+        if "uasc" in request.POST:
             historic_form = HistoricDataFilter(
-                initial=session_scenario.historic_filters,
-                la=datacontainer.unique_las,
-                ethnicity=datacontainer.unique_ethnicity,
-            )
-            historic_data = apply_filters(
-                datacontainer.enriched_view, historic_form.initial
-            )
-
-            # initialize form with default dates
-            predict_form = PredictFilter(
-                initial=session_scenario.prediction_parameters,
-                start_date=datacontainer.start_date,
-                end_date=datacontainer.end_date,
-            )
-
-        if historic_data.empty:
-            empty_dataframe = True
-            chart = None
-
-            transition_rates = None
-
-            exit_rates = None
-
-            entry_rates = None
-
-        else:
-            empty_dataframe = False
-
-            stats = PopulationStats(historic_data)
-
-            original_prediction = predict(
-                data=historic_data, **session_scenario.prediction_parameters
-            )
-
-            if (
-                session_scenario.adjusted_numbers is not None
-                or session_scenario.adjusted_rates is not None
-            ):
-                stats = PopulationStats(historic_data)
-
-                adjusted_prediction = predict(
-                    data=historic_data,
-                    **session_scenario.prediction_parameters,
-                    rate_adjustment=session_scenario.adjusted_rates,
-                    number_adjustment=session_scenario.adjusted_numbers,
-                )
-
-                # build chart
-                chart = compare_forecast(
-                    stats,
-                    original_prediction,
-                    adjusted_prediction,
-                    **session_scenario.prediction_parameters,
-                )
-
-                current_prediction = adjusted_prediction
-
-            else:
-                # build chart
-                chart = prediction_chart(
-                    stats, original_prediction, **session_scenario.prediction_parameters
-                )
-
-                current_prediction = original_prediction
-
-            transition_rates = transition_rate_table(
-                current_prediction.transition_rates
-            )
-
-            exit_rates = exit_rate_table(current_prediction.transition_rates)
-
-            entry_rates = entry_rate_table(current_prediction.entry_rates)
-
-        return render(
-            request,
-            "dm_regional_app/views/adjusted.html",
-            {
-                "predict_form": predict_form,
-                "historic_form": historic_form,
-                "chart": chart,
-                "empty_dataframe": empty_dataframe,
-                "transition_rate_table": transition_rates,
-                "exit_rate_table": exit_rates,
-                "entry_rate_table": entry_rates,
-            },
-        )
-    else:
-        next_url_name = "router_handler"
-        # Construct the URL for the router handler view and append the next_url_name as a query parameter
-        redirect_url = reverse(next_url_name) + "?next_url_name=" + "adjusted"
-        return redirect(redirect_url)
-
-
-@login_required
-def prediction(request):
-    if "session_scenario_id" in request.session:
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
-        # read data
-        datacontainer = read_data(source=settings.DATA_SOURCE)
-
-        if request.method == "POST":
-            if "uasc" in request.POST:
-                historic_form = HistoricDataFilter(
-                    request.POST,
-                    la=datacontainer.unique_las,
-                    ethnicity=datacontainer.unique_ethnicity,
-                )
-                predict_form = PredictFilter(
-                    initial=session_scenario.prediction_parameters,
-                    start_date=datacontainer.start_date,
-                    end_date=datacontainer.end_date,
-                )
-                if historic_form.is_valid():
-                    session_scenario.historic_filters = historic_form.cleaned_data
-                    session_scenario.save()
-
-                    historic_data = apply_filters(
-                        datacontainer.enriched_view, historic_form.cleaned_data
-                    )
-
-            if "reference_start_date" in request.POST:
-                predict_form = PredictFilter(
-                    request.POST,
-                    start_date=datacontainer.start_date,
-                    end_date=datacontainer.end_date,
-                )
-                historic_form = HistoricDataFilter(
-                    initial=session_scenario.historic_filters,
-                    la=datacontainer.unique_las,
-                    ethnicity=datacontainer.unique_ethnicity,
-                )
-
-                historic_data = apply_filters(
-                    datacontainer.enriched_view, historic_form.initial
-                )
-                if predict_form.is_valid():
-                    session_scenario.prediction_parameters = predict_form.cleaned_data
-                    session_scenario.save()
-
-        else:
-            historic_form = HistoricDataFilter(
-                initial=session_scenario.historic_filters,
-                la=datacontainer.unique_las,
-                ethnicity=datacontainer.unique_ethnicity,
-            )
-            historic_data = apply_filters(
-                datacontainer.enriched_view, historic_form.initial
-            )
-
-            # initialize form with default dates
-            predict_form = PredictFilter(
-                initial=session_scenario.prediction_parameters,
-                start_date=datacontainer.start_date,
-                end_date=datacontainer.end_date,
-            )
-
-        if historic_data.empty:
-            empty_dataframe = True
-            chart = None
-
-        else:
-            empty_dataframe = False
-
-            stats = PopulationStats(historic_data)
-
-            # Call predict function with default dates
-            prediction = predict(
-                data=historic_data, **session_scenario.prediction_parameters
-            )
-
-            # build chart
-            chart = prediction_chart(
-                stats, prediction, **session_scenario.prediction_parameters
-            )
-
-        return render(
-            request,
-            "dm_regional_app/views/prediction.html",
-            {
-                "predict_form": predict_form,
-                "historic_form": historic_form,
-                "chart": chart,
-                "empty_dataframe": empty_dataframe,
-            },
-        )
-    else:
-        next_url_name = "router_handler"
-        # Construct the URL for the router handler view and append the next_url_name as a query parameter
-        redirect_url = reverse(next_url_name) + "?next_url_name=" + "prediction"
-        return redirect(redirect_url)
-
-
-@login_required
-def historic_data(request):
-    if "session_scenario_id" in request.session:
-        pk = request.session["session_scenario_id"]
-        session_scenario = get_object_or_404(SessionScenario, pk=pk)
-        # read data
-        datacontainer = read_data(source=settings.DATA_SOURCE)
-
-        if request.method == "POST":
-            # initialize form with data
-            form = HistoricDataFilter(
                 request.POST,
                 la=datacontainer.unique_las,
                 ethnicity=datacontainer.unique_ethnicity,
             )
-
-            if form.is_valid():
-                # save cleaned data to session scenarios historic filters
-                session_scenario.historic_filters = form.cleaned_data
+            predict_form = PredictFilter(
+                initial=session_scenario.prediction_parameters,
+                start_date=datacontainer.start_date,
+                end_date=datacontainer.end_date,
+            )
+            if historic_form.is_valid():
+                session_scenario.historic_filters = historic_form.cleaned_data
                 session_scenario.save()
 
-                # update reference start and end
+                historic_data = apply_filters(
+                    datacontainer.enriched_view, historic_form.cleaned_data
+                )
 
-                data = apply_filters(datacontainer.enriched_view, form.cleaned_data)
-            else:
-                data = datacontainer.enriched_view
-        else:
-            # read data
-            datacontainer = read_data(source=settings.DATA_SOURCE)
-
-            # initialize form with default dates
-            form = HistoricDataFilter(
+        # check if it was predict filter form that was submitted
+        if "reference_start_date" in request.POST:
+            predict_form = PredictFilter(
+                request.POST,
+                start_date=datacontainer.start_date,
+                end_date=datacontainer.end_date,
+            )
+            historic_form = HistoricDataFilter(
                 initial=session_scenario.historic_filters,
                 la=datacontainer.unique_las,
                 ethnicity=datacontainer.unique_ethnicity,
             )
-            data = apply_filters(datacontainer.enriched_view, form.initial)
 
-        entry_into_care_count = data.loc[
-            data.placement_type_before == PlacementCategories.NOT_IN_CARE.value.label
-        ]["CHILD"].nunique()
-        exiting_care_count = data.loc[
-            data.placement_type_after == PlacementCategories.NOT_IN_CARE.value.label
-        ]["CHILD"].nunique()
+            historic_data = apply_filters(
+                datacontainer.enriched_view, historic_form.initial
+            )
+            if predict_form.is_valid():
+                session_scenario.prediction_parameters = predict_form.cleaned_data
+                session_scenario.save()
 
-        stats = PopulationStats(data)
-
-        chart = historic_chart(stats)
-
-        return render(
-            request,
-            "dm_regional_app/views/historic.html",
-            {
-                "form": form,
-                "entry_into_care_count": entry_into_care_count,
-                "exiting_care_count": exiting_care_count,
-                "chart": chart,
-            },
-        )
     else:
-        next_url_name = "router_handler"
-        # Construct the URL for the router handler view and append the next_url_name as a query parameter
-        redirect_url = reverse(next_url_name) + "?next_url_name=" + "historic_data"
-        return redirect(redirect_url)
+        historic_form = HistoricDataFilter(
+            initial=session_scenario.historic_filters,
+            la=datacontainer.unique_las,
+            ethnicity=datacontainer.unique_ethnicity,
+        )
+        historic_data = apply_filters(
+            datacontainer.enriched_view, historic_form.initial
+        )
+
+        # initialize form with default dates
+        predict_form = PredictFilter(
+            initial=session_scenario.prediction_parameters,
+            start_date=datacontainer.start_date,
+            end_date=datacontainer.end_date,
+        )
+
+    if historic_data.empty:
+        empty_dataframe = True
+        chart = None
+
+        transition_rates = None
+
+        exit_rates = None
+
+        entry_rates = None
+
+    else:
+        empty_dataframe = False
+
+        stats = PopulationStats(historic_data)
+
+        original_prediction = predict(
+            data=historic_data, **session_scenario.prediction_parameters
+        )
+
+        if (
+            session_scenario.adjusted_numbers is not None
+            or session_scenario.adjusted_rates is not None
+        ):
+            stats = PopulationStats(historic_data)
+
+            adjusted_prediction = predict(
+                data=historic_data,
+                **session_scenario.prediction_parameters,
+                rate_adjustment=session_scenario.adjusted_rates,
+                number_adjustment=session_scenario.adjusted_numbers,
+            )
+
+            # build chart
+            chart = compare_forecast(
+                stats,
+                original_prediction,
+                adjusted_prediction,
+                **session_scenario.prediction_parameters,
+            )
+
+            current_prediction = adjusted_prediction
+
+        else:
+            # build chart
+            chart = prediction_chart(
+                stats, original_prediction, **session_scenario.prediction_parameters
+            )
+
+            current_prediction = original_prediction
+
+        transition_rates = transition_rate_table(current_prediction.transition_rates)
+
+        exit_rates = exit_rate_table(current_prediction.transition_rates)
+
+        entry_rates = entry_rate_table(current_prediction.entry_rates)
+
+    return render(
+        request,
+        "dm_regional_app/views/adjusted.html",
+        {
+            "predict_form": predict_form,
+            "historic_form": historic_form,
+            "chart": chart,
+            "empty_dataframe": empty_dataframe,
+            "transition_rate_table": transition_rates,
+            "exit_rate_table": exit_rates,
+            "entry_rate_table": entry_rates,
+        },
+    )
+
+
+@login_required
+def prediction(request):
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    # read data
+    datacontainer = read_data(source=settings.DATA_SOURCE)
+
+    if request.method == "POST":
+        if "uasc" in request.POST:
+            historic_form = HistoricDataFilter(
+                request.POST,
+                la=datacontainer.unique_las,
+                ethnicity=datacontainer.unique_ethnicity,
+            )
+            predict_form = PredictFilter(
+                initial=session_scenario.prediction_parameters,
+                start_date=datacontainer.start_date,
+                end_date=datacontainer.end_date,
+            )
+            if historic_form.is_valid():
+                session_scenario.historic_filters = historic_form.cleaned_data
+                session_scenario.save()
+
+                historic_data = apply_filters(
+                    datacontainer.enriched_view, historic_form.cleaned_data
+                )
+
+        if "reference_start_date" in request.POST:
+            predict_form = PredictFilter(
+                request.POST,
+                start_date=datacontainer.start_date,
+                end_date=datacontainer.end_date,
+            )
+            historic_form = HistoricDataFilter(
+                initial=session_scenario.historic_filters,
+                la=datacontainer.unique_las,
+                ethnicity=datacontainer.unique_ethnicity,
+            )
+
+            historic_data = apply_filters(
+                datacontainer.enriched_view, historic_form.initial
+            )
+            if predict_form.is_valid():
+                session_scenario.prediction_parameters = predict_form.cleaned_data
+                session_scenario.save()
+
+    else:
+        historic_form = HistoricDataFilter(
+            initial=session_scenario.historic_filters,
+            la=datacontainer.unique_las,
+            ethnicity=datacontainer.unique_ethnicity,
+        )
+        historic_data = apply_filters(
+            datacontainer.enriched_view, historic_form.initial
+        )
+
+        # initialize form with default dates
+        predict_form = PredictFilter(
+            initial=session_scenario.prediction_parameters,
+            start_date=datacontainer.start_date,
+            end_date=datacontainer.end_date,
+        )
+
+    if historic_data.empty:
+        empty_dataframe = True
+        chart = None
+
+    else:
+        empty_dataframe = False
+
+        stats = PopulationStats(historic_data)
+
+        # Call predict function with default dates
+        prediction = predict(
+            data=historic_data, **session_scenario.prediction_parameters
+        )
+
+        # build chart
+        chart = prediction_chart(
+            stats, prediction, **session_scenario.prediction_parameters
+        )
+
+    return render(
+        request,
+        "dm_regional_app/views/prediction.html",
+        {
+            "predict_form": predict_form,
+            "historic_form": historic_form,
+            "chart": chart,
+            "empty_dataframe": empty_dataframe,
+        },
+    )
+
+
+@login_required
+def historic_data(request):
+    pk = request.session["session_scenario_id"]
+    session_scenario = get_object_or_404(SessionScenario, pk=pk)
+    # read data
+    datacontainer = read_data(source=settings.DATA_SOURCE)
+
+    if request.method == "POST":
+        # initialize form with data
+        form = HistoricDataFilter(
+            request.POST,
+            la=datacontainer.unique_las,
+            ethnicity=datacontainer.unique_ethnicity,
+        )
+
+        if form.is_valid():
+            # save cleaned data to session scenarios historic filters
+            session_scenario.historic_filters = form.cleaned_data
+            session_scenario.save()
+
+            # update reference start and end
+
+            data = apply_filters(datacontainer.enriched_view, form.cleaned_data)
+        else:
+            data = datacontainer.enriched_view
+    else:
+        # read data
+        datacontainer = read_data(source=settings.DATA_SOURCE)
+
+        # initialize form with default dates
+        form = HistoricDataFilter(
+            initial=session_scenario.historic_filters,
+            la=datacontainer.unique_las,
+            ethnicity=datacontainer.unique_ethnicity,
+        )
+        data = apply_filters(datacontainer.enriched_view, form.initial)
+
+    entry_into_care_count = data.loc[
+        data.placement_type_before == PlacementCategories.NOT_IN_CARE.value.label
+    ]["CHILD"].nunique()
+    exiting_care_count = data.loc[
+        data.placement_type_after == PlacementCategories.NOT_IN_CARE.value.label
+    ]["CHILD"].nunique()
+
+    stats = PopulationStats(data)
+
+    chart = historic_chart(stats)
+
+    return render(
+        request,
+        "dm_regional_app/views/historic.html",
+        {
+            "form": form,
+            "entry_into_care_count": entry_into_care_count,
+            "exiting_care_count": exiting_care_count,
+            "chart": chart,
+        },
+    )
 
 
 @login_required

--- a/dm_regional_app/views.py
+++ b/dm_regional_app/views.py
@@ -161,6 +161,9 @@ def costs(request):
     year_one_cost_base = number_format(year_one_cost_base)
     year_one_cost_difference = number_format(year_one_cost_difference)
 
+    transition_rate_table = None
+    exit_rate_table = None
+    entry_rate_table = None
     if session_scenario.adjusted_rates is not None:
         transition_rate_table = transition_rate_changes(
             base_prediction.transition_rates, prediction.transition_rates
@@ -168,16 +171,11 @@ def costs(request):
         exit_rate_table = exit_rate_changes(
             base_prediction.transition_rates, prediction.transition_rates
         )
-    else:
-        transition_rate_table = None
-        exit_rate_table = None
 
     if session_scenario.adjusted_numbers is not None:
         entry_rate_table = entry_rate_changes(
             base_prediction.entry_rates, prediction.entry_rates
         )
-    else:
-        entry_rate_table = None
 
     return render(
         request,

--- a/dm_regional_app/views.py
+++ b/dm_regional_app/views.py
@@ -70,66 +70,6 @@ def home(request):
 
 
 @login_required
-def router_handler(request):
-    # get next url page
-    next_url_name = request.GET.get("next_url_name")
-
-    # initialise a SessionScenario when the user is coming from a direct link to any of the views
-    session_scenario_id = request.session.get("session_scenario_id", None)
-    current_user = request.user
-
-    # read data
-    datacontainer = read_data(source=settings.DATA_SOURCE)
-
-    historic_filters = {
-        "la": [],
-        "ethnicity": [],
-        "sex": "all",
-        "uasc": "all",
-    }
-
-    prediction_parameters = {
-        "reference_start_date": datacontainer.start_date,
-        "reference_end_date": datacontainer.end_date,
-        "prediction_start_date": None,
-        "prediction_end_date": None,
-    }
-    historic_stock = {
-        "population": {},
-        "base_rates": [],
-    }
-    adjusted_costs = None
-
-    adjusted_rates = None
-
-    adjusted_proportions = None
-
-    inflation_parameters = {
-        "inflation": False,
-        "inflation_rate": 0.1,
-    }
-
-    # default_values should define the model default parameters, like reference_date and the stock data and so on. Decide what should be default with Michael
-    session_scenario, created = SessionScenario.objects.get_or_create(
-        id=session_scenario_id,
-        defaults={
-            "user_id": current_user.id,
-            "historic_filters": historic_filters,
-            "prediction_parameters": prediction_parameters,
-            "historic_stock": historic_stock,
-            "adjusted_costs": adjusted_costs,
-            "adjusted_rates": adjusted_rates,
-            "adjusted_proportions": adjusted_proportions,
-            "inflation_parameters": inflation_parameters,
-        },
-    )
-
-    # update the request session
-    request.session["session_scenario_id"] = session_scenario.pk
-    return redirect(next_url_name)
-
-
-@login_required
 def costs(request):
     pk = request.session["session_scenario_id"]
     session_scenario = get_object_or_404(SessionScenario, pk=pk)

--- a/dm_regional_site/settings/base.py
+++ b/dm_regional_site/settings/base.py
@@ -71,6 +71,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "dm_regional_app.middleware.scenario_middleware.SessionScenarioMiddleware",
 ]
 
 MICROSOFT_CLIENT_ID = config("MICROSOFT_CLIENT_ID", default="")


### PR DESCRIPTION
This update will remove the `router_handler` function and instead use a custom middleware. Middleware is applied to every request/response so now all views will have a `session_scenario_id` stored in the session. 

`views.py` changes look extensive, but for each function all I did was remove the conditional that checks for the id in the session. Probably easiest to see those changes within this commit itself: https://github.com/SocialFinanceDigitalLabs/cs-demand-model-regional/commit/5f7c6c0af2ea32d5426858fc1a8bac59c0b35d23

Note: If there are no data uploads, the middleware will redirect the user to the home screen with a message:
![image](https://github.com/user-attachments/assets/55463214-469e-4770-b9d6-b349c69795ff)


