### PR TITLE
remove age transition episodes from placement starts graph

### DIFF
--- a/dm_regional_app/charts.py
+++ b/dm_regional_app/charts.py
@@ -295,16 +295,19 @@ def placement_starts_chart(data: PopulationStats, start_date: str, end_date: str
     Outputs an html figure of placement counts over time from the stock in population stats
     """
     df_stats_data = data.df.copy()
-
     start_date, end_date = pd.to_datetime([start_date, end_date])
-    df_stats_data["DECOM"] = (
-        df_stats_data["DECOM"].dt.to_period("M").dt.to_timestamp()
-    )  # requ format for plot timestamps (mths)
 
-    # filter time-frame to passed/form dates
+    # filter dataset to:
+    # - data start and end dates
+    # - remove episodes that are just due to age transitions
     df_filtered = df_stats_data[
-        (df_stats_data["DECOM"] >= start_date) & (df_stats_data["DECOM"] <= end_date)
+        (df_stats_data["DECOM"] >= start_date)
+        & (df_stats_data["DECOM"] <= end_date)
+        & (df_stats_data["RNE"] != "A")
     ]
+
+    # Change DECOMs to beginning of each month to facilitate graph showing events by month
+    df_filtered["DECOM"] = df_filtered["DECOM"].dt.to_period("M").dt.to_timestamp()
 
     # calculate placement duration (end_age - age)
     df_filtered.loc[:, "placement_duration"] = (

--- a/ssda903/datacontainer.py
+++ b/ssda903/datacontainer.py
@@ -315,6 +315,7 @@ class DemandModellingDataContainer:
                         old_row["REASON_PLACE_CHANGE"] = ""
                         old_row["end_age"] = age_bound
                         new_row["DECOM"] = row["DOB"] + pd.DateOffset(years=age_bound)
+                        new_row["RNE"] = "A"  # A for age
                         new_row["age"] = age_bound
                         expanded_df.append(old_row)
                         expanded_df.append(new_row)


### PR DESCRIPTION
Simple one - small change to datacontainer to better identify episodes that are created to represent age transitions; then change in placement_starts_chart to remove these episodes from the graph