### PR TITLE
Populating 0 rates

### DIFF
--- a/dm_regional_app/charts.py
+++ b/dm_regional_app/charts.py
@@ -485,7 +485,7 @@ def exit_rate_table(data):
     # if dataframe has 3 columns, order and rename them and round values
     if df.shape[1] == 3:
         df = df[["Age Group", "Placement", "rates"]]
-        df.columns = ["Age Group", "Placement", "Base entry rate"]
+        df.columns = ["Age Group", "Placement", "Base exit rate"]
         df = df.round(4)
 
     return df


### PR DESCRIPTION
Code added to population stats to ensure all possible rates for the dataset are created (eg. If 10-16 Fostering and 10-16 Residential exist in the dataset, both transitions to and from these must exist).

No changes made to entry rates, it appears that with the change to exit rates, `build_transition_rates_matrix()` ensures proper entry rates are applied, have tested across a number of scenarios.

Typo fix - Exit rate table said Entry rate in the header.