### PR TITLE
feat: add link to admin page for admin users

### DIFF
--- a/dm_regional_app/templates/dm_regional_app/includes/navbar.html
+++ b/dm_regional_app/templates/dm_regional_app/includes/navbar.html
@@ -23,6 +23,7 @@
           {% get_social_accounts user as accounts %}
           {% if user.is_staff and accounts %}
                 {% include 'dm_regional_app/includes/navbar-item.html' with url='upload_data' name='Data Source Upload' url_names="['upload_data']" %}
+                {% include 'dm_regional_app/includes/navbar-item.html' with url='admin:index' name='Admin' %}
           {% endif %}
         {% else %}
           {% include 'dm_regional_app/includes/navbar-item.html' with url='home' name='Home' url_names="['home']" %}


### PR DESCRIPTION
So admin users can easily navigate to the admin interface for creating users

<img width="533" alt="image" src="https://github.com/user-attachments/assets/b7009382-5c6b-4c06-83fb-c93d887c4449" />
