### PR TITLE
Don't remove nas from average rate calculation

### DIFF
--- a/ssda903/population_stats.py
+++ b/ssda903/population_stats.py
@@ -143,7 +143,6 @@ class PopulationStats:
         # Calculate the transition rates
         stock, transitions = stock.align(transitions)
         transition_rates = transitions / stock.shift(1).fillna(method="bfill")
-        transition_rates = transition_rates.fillna(0)
 
         # Use the mean rates
         transition_rates = transition_rates.mean(axis=0)


### PR DESCRIPTION
Really simple change: removed the line in transition_rates calculation where nas were changed to 0. This is incorrect, as this happens when the stock is 0. These days should not contribute to rate calculations, as they will artificially lower the overall rate.