### PR TITLE
110 rate normalisation in multinomial

### DIFF
--- a/dm_regional_app/forms.py
+++ b/dm_regional_app/forms.py
@@ -410,6 +410,13 @@ class DynamicRateForm(forms.Form):
                     "You cannot multiply a rate if the original rate is 0",
                 )
 
+            # Validation logic: add value can't be more than 1
+            if add_value is not None and add_value > 1:
+                self.add_error(
+                    add_field_name,
+                    "You cannot add more than 1 to a rate",
+                )
+
         return cleaned_data
 
     def save(self):

--- a/dm_regional_app/forms.py
+++ b/dm_regional_app/forms.py
@@ -410,12 +410,13 @@ class DynamicRateForm(forms.Form):
                     "You cannot multiply a rate if the original rate is 0",
                 )
 
-            # Validation logic: add value can't be more than 1
-            if add_value is not None and add_value > 1:
-                self.add_error(
-                    add_field_name,
-                    "You cannot add more than 1 to a rate",
-                )
+            # Validation logic: add value can't be more than 1 for rates
+            if self.series.name != "daily_entry_probability":
+                if add_value is not None and add_value > 1:
+                    self.add_error(
+                        add_field_name,
+                        "You cannot add more than 1 to a rate",
+                    )
 
         return cleaned_data
 

--- a/dm_regional_app/templates/dm_regional_app/views/adjusted.html
+++ b/dm_regional_app/templates/dm_regional_app/views/adjusted.html
@@ -65,10 +65,15 @@
                   </button>
             </div>
             <div class="card-body">
-                <p>Once you have adjusted the table you will be able to see the base 
-                forecast alongside your adjusted forecast to compare. You can 
-                continue to edit the table across each of the views.</p>
-                <p>Rates in these tables include any previous adjustments you might have made.</p>
+                <p>
+                    Once you have adjusted the table you will be able to see the base 
+                    forecast alongside your adjusted forecast to compare. You can 
+                    continue to edit the table across each of the views.
+                </p>
+                <p>
+                    Rates in these tables are the result of combining the base rates and any adjustments you have made.
+                    You can view the base rates and associated adjustments by clicking the 'Edit this table' button.
+                </p>
                 <div class="accordion-group">
                     <div class="collapse indent" id="entering_care" data-bs-parent="#tables">
                         <div class="card card-body">

--- a/dm_regional_app/templates/dm_regional_app/views/entry_rates.html
+++ b/dm_regional_app/templates/dm_regional_app/views/entry_rates.html
@@ -8,12 +8,16 @@
 <br>
     <h1>Adjust entry rates</h1>
     <br>
-    <p>You may want to edit the number of children per year entering care to give a more accurate
-        picture of future forecasting or simply to explore what changes you may expect to see. </p>
-    <p>Rates are applied to the daily population of children. For example, a rate of 0.5 to 10-16 Fostering 
-        would mean that every two days a child would enter this placement.
+    <p>
+        You may want to edit the number of children per year entering care to give a more accurate
+        picture of future forecasting or simply to explore what changes you may expect to see. 
     </p>
-    <p>Rate multiplication multiplies the initial base rate produced by the model parameters you selected.
+    <p>
+        Entry rates represent the number of children entering a placement each day. For example, a rate of 
+        0.5 in 10-16 Fostering would mean that every two days a child would enter this placement.
+    </p>
+    <p>
+        Adjustments are always applied to the initial base rate produced by the model parameters you selected, they do not replace them.
     </p>
         <div class="table-responsive">
             <table id="transition-rate" class="table table-hover">

--- a/dm_regional_app/templates/dm_regional_app/views/entry_rates.html
+++ b/dm_regional_app/templates/dm_regional_app/views/entry_rates.html
@@ -9,7 +9,7 @@
     <h1>Adjust entry rates</h1>
     <br>
     <p>
-        You may want to edit the number of children per year entering care to give a more accurate
+        You may want to edit the number of children per day entering care to give a more accurate
         picture of future forecasting or simply to explore what changes you may expect to see. 
     </p>
     <p>
@@ -17,7 +17,7 @@
         0.5 in 10-16 Fostering would mean that every two days a child would enter this placement.
     </p>
     <p>
-        Adjustments are always applied to the initial base rate produced by the model parameters you selected, they do not replace them.
+        Adjustments are always applied to the initial base rate produced by the model parameters you selected.
     </p>
         <div class="table-responsive">
             <table id="transition-rate" class="table table-hover">

--- a/dm_regional_app/templates/dm_regional_app/views/exit_rates.html
+++ b/dm_regional_app/templates/dm_regional_app/views/exit_rates.html
@@ -9,7 +9,7 @@
     <h1>Adjust exit rates</h1>
     <br>
     <p>
-        You may want to edit the number of children per year exiting care to give a more accurate
+        You may want to edit the number of children per day exiting care to give a more accurate
         picture of future forecasting or simply to explore what changes you may expect to see. 
     </p>
     <p>
@@ -17,7 +17,7 @@
         would mean that each day, 50% of children in Fostering will leave care.
     </p>
     <p>
-        Adjustments are always applied to the initial base rate produced by the model parameters you selected, they do not replace them. 
+        Adjustments are always applied to the initial base rate produced by the model parameters you selected. 
     </p>
     <p>
         If changes you make to rates results in a placement type having rates that sum to more than 1, the model will adjust the rates to sum to 1. 

--- a/dm_regional_app/templates/dm_regional_app/views/exit_rates.html
+++ b/dm_regional_app/templates/dm_regional_app/views/exit_rates.html
@@ -8,13 +8,22 @@
 <br>
     <h1>Adjust exit rates</h1>
     <br>
-    <p>You may want to edit the number of children per year exiting care to give a more accurate
-        picture of future forecasting or simply to explore what changes you may expect to see. </p>
-        <p>
+    <p>
+        You may want to edit the number of children per year exiting care to give a more accurate
+        picture of future forecasting or simply to explore what changes you may expect to see. 
+    </p>
+    <p>
         Rates are applied to the daily population of children. For example, a rate of 0.5 from 10-16 Fostering 
         would mean that each day, 50% of children in Fostering will leave care.
     </p>
-    <p>Rate multiplication multiplies the initial base rate produced by the model parameters you selected.
+    <p>
+        Adjustments are always applied to the initial base rate produced by the model parameters you selected, they do not replace them. 
+    </p>
+    <p>
+        If changes you make to rates results in a placement type having rates that sum to more than 1, the model will adjust the rates to sum to 1. 
+        For example, if you set the rate for children in leaving 5-10 Fostering to 0.5 and the rate for children moving from 5-10 Fostering to 
+        Residential to 0.6, the model will scale these down (to 0.45 and 0.55 respectively) and set any other rates for that placement 
+        (e.g. 5-10 Fostering to Other) to 0. You can view the results of your rate adjustments on <a href="{% url 'adjusted' %}">Adjust Forecast</a>.
     </p>
         <div class="table-responsive">
             <table id="transition-rate" class="table table-hover">

--- a/dm_regional_app/templates/dm_regional_app/views/transition_rates.html
+++ b/dm_regional_app/templates/dm_regional_app/views/transition_rates.html
@@ -8,10 +8,22 @@
 <br>
     <h1>Adjust transition rates</h1>
     <br>
-    <p>You may want to edit the number of children per year entering a placement type to give a more accurate
-        picture of future forecasting or simply to explore what changes you may expect to see. <br><br>
+    <p>
+        You may want to edit the number of children per year entering a placement type to give a more accurate
+        picture of future forecasting or simply to explore what changes you may expect to see. 
+    </p>
+    <p>
         Rates are applied to the daily population of children. For example, a rate of 0.5 from Fostering to Residential means
-        that each day, 50% of children in Fostering will move to Residential.<br>
+        that each day, 50% of children in Fostering will move to Residential.
+    </p>
+    <p>
+        Adjustments are always applied to the initial base rate produced by the model parameters you selected, they do not replace them. 
+    </p>
+    <p>
+        If changes you make to rates results in a placement type having rates that sum to more than 1, the model will adjust the rates to sum to 1. 
+        For example, if you set the rate for children in leaving 5-10 Fostering to 0.5 and the rate for children moving from 5-10 Fostering to 
+        Residential to 0.6, the model will scale these down (to 0.45 and 0.55 respectively) and set any other rates for that placement 
+        (e.g. 5-10 Fostering to Other) to 0. You can view the results of your rate adjustments on <a href="{% url 'adjusted' %}">Adjust Forecast</a>.
     </p>
         <div class="table-responsive">
             <table id="transition-rate" class="table table-hover">

--- a/dm_regional_app/templates/dm_regional_app/views/transition_rates.html
+++ b/dm_regional_app/templates/dm_regional_app/views/transition_rates.html
@@ -9,7 +9,7 @@
     <h1>Adjust transition rates</h1>
     <br>
     <p>
-        You may want to edit the number of children per year entering a placement type to give a more accurate
+        You may want to change the rate of children per day moving between different placement types to give a more accurate
         picture of future forecasting or simply to explore what changes you may expect to see. 
     </p>
     <p>
@@ -17,7 +17,7 @@
         that each day, 50% of children in Fostering will move to Residential.
     </p>
     <p>
-        Adjustments are always applied to the initial base rate produced by the model parameters you selected, they do not replace them. 
+        Adjustments are always applied to the initial base rate produced by the model parameters you selected. 
     </p>
     <p>
         If changes you make to rates results in a placement type having rates that sum to more than 1, the model will adjust the rates to sum to 1. 

--- a/ssda903/population_stats.py
+++ b/ssda903/population_stats.py
@@ -304,6 +304,7 @@ class PopulationStats:
         end_date = pd.to_datetime(reference_end_date)
 
         df = self.df.copy()
+        print(df)
 
         # Only look at episodes starting in analysis period
         df = df[(df["DECOM"] >= start_date) & (df["DECOM"] <= end_date)].copy()

--- a/ssda903/tests/test_daily_entrants.py
+++ b/ssda903/tests/test_daily_entrants.py
@@ -1,0 +1,83 @@
+import unittest
+
+import pandas as pd
+
+from ssda903.population_stats import PopulationStats
+
+
+class TestDailyEntryProbability(unittest.TestCase):
+    def setUp(self):
+        """Set up test data before each test."""
+        data = {
+            "CHILD": [290, 519, 519, 519],
+            "DECOM": pd.to_datetime(
+                ["2016-11-19", "2017-03-09", "2017-09-14", "2018-03-26"]
+            ),
+            "RNE": ["T", "P", "S", "A"],
+            "LS": ["D1", "J2", "D1", "D1"],
+            "CIN": ["N5", "N6", "N8", "N8"],
+            "PLACE": ["U5", "U4", "U5", "U5"],
+            "PLACE_PROVIDER": ["PR4", "PR1", "PR4", "PR4"],
+            "age_bin": ["16 to 18+", "10 to 16", "10 to 16", "16 to 18+"],
+            "end_age_bin": ["16 to 18+", "10 to 16", "16 to 18+", "16 to 18+"],
+            "placement_type": ["Fostering", "Fostering", "Fostering", "Fostering"],
+            "placement_type_before": [
+                "Not in care",
+                "Not in care",
+                "Fostering",
+                "Fostering",
+            ],
+            "placement_type_after": [
+                "Not in care",
+                "Fostering",
+                "Fostering",
+                "Not in care",
+            ],
+            "placement_type_detail": [
+                "Fostering (IFA)",
+                "Fostering (In-house)",
+                "Fostering (IFA)",
+                "Fostering (IFA)",
+            ],
+            "ethnicity": [
+                "White and Black Caribbean",
+                "Any other Asian background",
+                "Any other Asian background",
+                "Any other Asian background",
+            ],
+        }
+        self.sample_data = pd.DataFrame(data)
+
+        self.data_start_date = pd.to_datetime(self.sample_data["DECOM"].min())
+        self.data_end_date = pd.to_datetime(self.sample_data["DECOM"].max())
+
+    def test_output_is_series(self):
+        """Test if function output is a pandas Series."""
+        stats = PopulationStats(
+            df=self.sample_data,
+            data_start_date=self.data_start_date,
+            data_end_date=self.sample_data["DECOM"].max(),
+        )
+        result = stats.daily_entrants(
+            reference_start_date=self.data_start_date,
+            reference_end_date=self.data_end_date,
+        )
+        self.assertIsInstance(result, pd.Series, "Output is not a pandas Series")
+
+    def test_series_name(self):
+        """
+        Test if the Series name is 'daily_entry_probability'.
+        This is a requirement for validation on DynamicRateForm
+        """
+        stats = PopulationStats(
+            df=self.sample_data,
+            data_start_date=self.data_start_date,
+            data_end_date=self.data_end_date,
+        )
+
+        daily_entrants = stats.daily_entrants(
+            reference_start_date=self.data_start_date,
+            reference_end_date=self.data_end_date,
+        )
+        result = daily_entrants.name
+        self.assertEqual(result, "daily_entry_probability", "Series name is incorrect")


### PR DESCRIPTION
Normalises rates when combining rates in multinomial, prioritising adjustments over unadjusted rates
Restricts users from adding more than 1 to a rate
Updates explanatory text to communicate changes

Rates summing to less than 1 are handled by `populate_same_state_transition`. This replaces the same state transition with 1-all other related rates, even if the same state transition already exists.