### PR TITLE
fix: add auth to data upload decorator

### DIFF
--- a/dm_regional_app/decorators.py
+++ b/dm_regional_app/decorators.py
@@ -10,7 +10,8 @@ def user_is_admin(view_func):
     @wraps(view_func)
     def wrapper(request, *args, **kwargs):
         if (
-            request.user.socialaccount_set.exists()
+            request.user.is_authenticated
+            and request.user.socialaccount_set.exists()
             and request.user.is_active
             and request.user.is_staff
         ):


### PR DESCRIPTION
The user already needed to be authenticated, but if they weren't the system was erroring out. This will give a helpful error to any end users.