### PR TITLE
clear session scenarios on data upload

### DIFF
--- a/dm_regional_app/templates/dm_regional_app/views/upload_data_source.html
+++ b/dm_regional_app/templates/dm_regional_app/views/upload_data_source.html
@@ -5,6 +5,7 @@
 <h1 class="mt-4">Data Source Upload</h1>
 
 <div class="row mt-4">
+    <p>Please note that uploading new data will clear users' current session data. Consider notifying users in advance of upload.</p>
     <div class="card">
         <div class="card-body">
             <form method="post" enctype="multipart/form-data">

--- a/dm_regional_app/views.py
+++ b/dm_regional_app/views.py
@@ -1328,6 +1328,9 @@ def upload_data_source(request):
                         default_storage.delete(full_path)
                     default_storage.save(full_path, file)
                 messages.success(request, "Data uploaded successfully")
+
+                SessionScenario.objects.all().delete()
+                messages.success(request, "Session scenarios cleared")
             else:
                 messages.error(request, f"Data not uploaded successfully: {msg}")
             return redirect("upload_data")


### PR DESCRIPTION
Session scenarios cleared on data upload - prevents errors for users if scenario inputs are not available in newly uploaded data