### PR TITLE
feat: remove user permissions from admin

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -28,7 +28,6 @@ class UserAdmin(DjangoUserAdmin):
                     "is_staff",
                     "is_superuser",
                     "groups",
-                    "user_permissions",
                 )
             },
         ),


### PR DESCRIPTION
Removes the ability for admin users to adjust permissions on regular users within the admin panel.
Note: this does not change their abilities to do so programmatically!

<img width="1608" height="828" alt="image" src="https://github.com/user-attachments/assets/3e4f4b62-7e41-4d17-af37-6f7900d81bb4" />
