### PR TITLE
feat: set session cookie expire default to 5 days

### DIFF
--- a/dm_regional_site/settings/base.py
+++ b/dm_regional_site/settings/base.py
@@ -173,6 +173,8 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+SESSION_COOKIE_AGE = config("SESSION_COOKIE_AGE", 432000)
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/


### PR DESCRIPTION
Django defaults to allowing sessions to stay alive for 14 days. The penetration test results dictated that that was too long. We need to find the middle ground between usability and security! So have defaulted to 5 days for now, but it can be configured as an env var in Heroku