### PR TITLE
feat: set default minimum password length to 12

### DIFF
--- a/dm_regional_site/settings/base.py
+++ b/dm_regional_site/settings/base.py
@@ -164,6 +164,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {
+            "min_length": config("MINIMUM_PASSWORD_LENGTH", 12, cast=int),
+        },
     },
     {
         "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",


### PR DESCRIPTION
The penetration test results said the minimum password length was too short and suggested it be 12. I believe Michala's suggestion is 15 with rotation every 180 days. This PR sets the default to 12, but makes it configurable. Forced password rotation would need to be a separate PR. 