### PR TITLE
remove int typing

### DIFF
--- a/dm_regional_app/utils.py
+++ b/dm_regional_app/utils.py
@@ -394,7 +394,7 @@ def weekly_care_type_dfs(
     ).first()
 
     if round_int:
-        weekly = weekly.round().astype(int)
+        weekly = weekly.round()
 
     out = weekly.unstack().reset_index()
     out.columns = ["bin", "date", value_col]


### PR DESCRIPTION
Turns out, plotly will display a round number float as a whole number anyway, so casting as int was not necessary here. The `.astype(int)` was the part causing the problem - `.round()` will ignore NANs or infs