### PR TITLE
restrict prediction end date

### DIFF
--- a/dm_regional_app/forms.py
+++ b/dm_regional_app/forms.py
@@ -92,6 +92,13 @@ class PredictFilter(forms.Form):
                     "Prediction start date must be before prediction end date."
                 )
 
+        # if prediction end date is not blank and more than 4 years after prediction start date, raise error
+        if prediction_start_date and prediction_end_date:
+            if prediction_end_date > prediction_start_date + pd.DateOffset(years=4):
+                raise forms.ValidationError(
+                    "Prediction end date must be within 4 years of prediction start date."
+                )
+
 
 class HistoricDataFilter(forms.Form):
     la = forms.MultipleChoiceField(


### PR DESCRIPTION
as demonstrated by Patrick in our stress testing session, users trying to create an extremely long prediction could cause a timeout on the page. this prevents that behaviour