### PR TITLE
remove sort on related placement type

### DIFF
--- a/ssda903/datacontainer.py
+++ b/ssda903/datacontainer.py
@@ -453,8 +453,6 @@ class DemandModellingDataContainer:
 
         WARNING: This method modifies the dataframe in place.
         """
-        combined = combined.sort_values(["CHILD", "DECOM", "DEC"], na_position="first")
-
         # Group by child and set next/preceding placement based on offset
         # Set any blank values (where next/preceding episode is not the same child) as Not in Care
         combined[new_column_name] = (


### PR DESCRIPTION
This is a simple change to remove an unnecessary legacy sort from the function to add related placement types.

We perform this sort earlier in the transformation set, where it is required. Here, it creates an issue with the new episodes that have been added to represent age transitions, as these will have the same DECOM as the following episode. If that episode does not have a value for DEC, the assignment of next and previous placements will be incorrect, creating transitions that should not exist.

Tested with v2 sample files - only the incorrect transitions recorded for children 601115 and 627374 were removed and correct replacements added e.g. removal of 5-10 Fostering  -> 10- 16 Other and replacement with 5-10 Fostering -> 10-16 Fostering